### PR TITLE
Migrate to .NET 5.0 + Update to Avalonia 0.10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ build:
   parallel: false
   verbosity: minimal
 after_test:
-  - ps: $env:TGCPVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$env:APPVEYOR_BUILD_FOLDER/src/Tgstation.Server.ControlPanel/bin/$env:CONFIGURATION/netcoreapp3.1/Tgstation.Server.ControlPanel.dll").FileVersion
+  - ps: $env:TGCPVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$env:APPVEYOR_BUILD_FOLDER/src/Tgstation.Server.ControlPanel/bin/$env:CONFIGURATION/net5.0/Tgstation.Server.ControlPanel.dll").FileVersion
   - ps: if($env:APPVEYOR_REPO_COMMIT_MESSAGE -match "\[TGSDeploy\]"){ if($env:APPVEYOR_REPO_BRANCH -match "master"){ if($env:CONFIGURATION -match "Release"){ $env:TGSDeploy = "Do it." }}}
 deploy:
   - provider: GitHub

--- a/src/Tgstation.Server.ControlPanel/App.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/App.xaml.cs
@@ -1,10 +1,38 @@
 ﻿using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using System.Net;
+using Tgstation.Server.ControlPanel.ViewModels;
+using Tgstation.Server.ControlPanel.Views;
 
 namespace Tgstation.Server.ControlPanel
 {
     public sealed class App : Application
     {
         public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+        public override void OnFrameworkInitializationCompleted()
+        {
+            // Add Tls1.2 to the existing enabled protocols
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
+            using var mwvm = new MainWindowViewModel(new NotificationUpdater());
+            mwvm.AsyncStart();
+
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
+                desktop.MainWindow = new MainWindow()
+                {
+                    DataContext = mwvm
+                };
+            }
+            else if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)
+            {
+                singleView.MainView = new MainView()
+                {
+                    DataContext = mwvm
+                };
+            }
+            base.OnFrameworkInitializationCompleted();
+        }
     }
 }

--- a/src/Tgstation.Server.ControlPanel/ControlPanel.cs
+++ b/src/Tgstation.Server.ControlPanel/ControlPanel.cs
@@ -1,27 +1,9 @@
-﻿using Avalonia;
-using Avalonia.Logging.Serilog;
-using Avalonia.ReactiveUI;
-using System.Diagnostics;
-using System.Linq;
-using System.Net;
-using Tgstation.Server.ControlPanel.ViewModels;
-using Tgstation.Server.ControlPanel.Views;
+﻿using System.Diagnostics;
 
 namespace Tgstation.Server.ControlPanel
 {
 	public static class ControlPanel
 	{
-		public static void Run(IUpdater updater, AppBuilder app)
-		{
-			// Add Tls1.2 to the existing enabled protocols
-			ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
-
-			using var mwvm = new MainWindowViewModel(updater);
-
-			mwvm.AsyncStart();
-			app.Start<MainWindow>(() => mwvm);
-		}
-
 		public static void OpenFolder(string folder) => Process.Start(folder);
 		public static void LaunchUrl(string url)
 		{

--- a/src/Tgstation.Server.ControlPanel/Program.cs
+++ b/src/Tgstation.Server.ControlPanel/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia;
-using Avalonia.Logging.Serilog;
 using Avalonia.ReactiveUI;
 using System.Linq;
 
@@ -7,7 +6,7 @@ namespace Tgstation.Server.ControlPanel
 {
 	static class Program
 	{
-		public static void Main(string[] args) => ControlPanel.Run(new NotificationUpdater(), BuildAvaloniaApp(args));
+		public static void Main(string[] args) => BuildAvaloniaApp(args).StartWithClassicDesktopLifetime(args);
 
 		public static AppBuilder BuildAvaloniaApp(string[] args)
 		{
@@ -15,14 +14,13 @@ namespace Tgstation.Server.ControlPanel
 			if (args.FirstOrDefault()?.ToUpperInvariant() == "--WIN32-HACK")
 				app
 					.UseWin32()
-					.UseDirect2D1()
 					.UseReactiveUI()
-					.LogToDebug();
+					.LogToTrace();
 			else
 				app
 					.UsePlatformDetect()
 					.UseReactiveUI()
-					.LogToDebug();
+					.LogToTrace();
 
 			return app;
 		}

--- a/src/Tgstation.Server.ControlPanel/Tgstation.Server.ControlPanel.csproj
+++ b/src/Tgstation.Server.ControlPanel/Tgstation.Server.ControlPanel.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>1.14.6</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -66,9 +66,10 @@
     </AvaloniaXaml>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.9.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.12" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.12" />
+    <PackageReference Include="Avalonia" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.0" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="5.0.0" />


### PR DESCRIPTION
Migrates the application to .NET 5.0, and updates Avalonia from 0.9.12 to 0.10.0

Note that in migrating to Avalonia 0.10, I've also gone ahead and attempted to implement the new [application lifetime pattern](https://github.com/AvaloniaUI/Avalonia/wiki/Application-lifetimes), as the old method of using ``Start<T>`` was deprecated. As a result, ``Tgstation.Server.ControlPanel.ControlPanel.Run(...)`` was killed in the process, as it no longer fit the new model, but let me know if this was a bad move or if there is a better way of doing it.

Admittedly I just wanted to update the package but I had build errors and warnings screaming at me.

Best wishes,
bobbah 'bee' brown