### PR TITLE
Add EditorConfig to enforce code styling prefs + code cleanup pass

### DIFF
--- a/src/Tgstation.Server.ControlPanel/.editorconfig
+++ b/src/Tgstation.Server.ControlPanel/.editorconfig
@@ -1,0 +1,124 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/src/Tgstation.Server.ControlPanel/.editorconfig
+++ b/src/Tgstation.Server.ControlPanel/.editorconfig
@@ -5,7 +5,7 @@
 root = true
 # All files
 [*]
-indent_style = space
+indent_style = tab
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
@@ -66,7 +66,7 @@ csharp_style_var_for_built_in_types = true:silent
 csharp_style_var_when_type_is_apparent = true:silent
 csharp_style_var_elsewhere = true:silent
 # Expression-bodied members
-csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
 csharp_style_expression_bodied_constructors = false:silent
 csharp_style_expression_bodied_operators = false:silent
 csharp_style_expression_bodied_properties = true:silent

--- a/src/Tgstation.Server.ControlPanel/.editorconfig
+++ b/src/Tgstation.Server.ControlPanel/.editorconfig
@@ -66,7 +66,7 @@ csharp_style_var_for_built_in_types = true:silent
 csharp_style_var_when_type_is_apparent = true:silent
 csharp_style_var_elsewhere = true:silent
 # Expression-bodied members
-csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_methods = false:silent
 csharp_style_expression_bodied_constructors = false:silent
 csharp_style_expression_bodied_operators = false:silent
 csharp_style_expression_bodied_properties = true:silent

--- a/src/Tgstation.Server.ControlPanel/App.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/App.xaml.cs
@@ -1,38 +1,39 @@
-﻿using Avalonia;
+﻿using System.Net;
+using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
-using System.Net;
 using Tgstation.Server.ControlPanel.ViewModels;
 using Tgstation.Server.ControlPanel.Views;
 
 namespace Tgstation.Server.ControlPanel
 {
-    public sealed class App : Application
-    {
-        public override void Initialize() => AvaloniaXamlLoader.Load(this);
+	public sealed class App : Application
+	{
+		public override void Initialize() => AvaloniaXamlLoader.Load(this);
 
-        public override void OnFrameworkInitializationCompleted()
-        {
-            // Add Tls1.2 to the existing enabled protocols
-            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+		public override void OnFrameworkInitializationCompleted()
+		{
+			// Add Tls1.2 to the existing enabled protocols
+			ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
-            using var mwvm = new MainWindowViewModel(new NotificationUpdater());
-            mwvm.AsyncStart();
+			using var mwvm = new MainWindowViewModel(new NotificationUpdater());
+			mwvm.AsyncStart();
 
-            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
-                desktop.MainWindow = new MainWindow()
-                {
-                    DataContext = mwvm
-                };
-            }
-            else if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)
-            {
-                singleView.MainView = new MainView()
-                {
-                    DataContext = mwvm
-                };
-            }
-            base.OnFrameworkInitializationCompleted();
-        }
-    }
+			if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+			{
+				desktop.MainWindow = new MainWindow()
+				{
+					DataContext = mwvm
+				};
+			}
+			else if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)
+			{
+				singleView.MainView = new MainView()
+				{
+					DataContext = mwvm
+				};
+			}
+			base.OnFrameworkInitializationCompleted();
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/IUpdater.cs
+++ b/src/Tgstation.Server.ControlPanel/IUpdater.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tgstation.Server.ControlPanel

--- a/src/Tgstation.Server.ControlPanel/InstanceJobSink.cs
+++ b/src/Tgstation.Server.ControlPanel/InstanceJobSink.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Client;
 using Tgstation.Server.Client.Components;
-using Tgstation.Server.ControlPanel.ViewModels;
 
 namespace Tgstation.Server.ControlPanel
 {

--- a/src/Tgstation.Server.ControlPanel/InstanceJobSink.cs
+++ b/src/Tgstation.Server.ControlPanel/InstanceJobSink.cs
@@ -142,7 +142,7 @@ namespace Tgstation.Server.ControlPanel
 				foreach (var I in trackedJobs)
 					tasks.Add(WrapJobDisconnected(I.Value));
 
-			Task.WhenAll(tasks).ContinueWith((a) => linkedSource.Dispose());
+			Task.WhenAll(tasks).ContinueWith((a) => linkedSource.Dispose(), cancellationToken);
 
 			return tasks.Select(x => x.ToObservable()).Merge();
 		}

--- a/src/Tgstation.Server.ControlPanel/LoggingHandler.cs
+++ b/src/Tgstation.Server.ControlPanel/LoggingHandler.cs
@@ -1,8 +1,8 @@
-﻿using Octokit.Internal;
-using System;
+﻿using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Octokit.Internal;
 using Tgstation.Server.Client;
 
 namespace Tgstation.Server.ControlPanel

--- a/src/Tgstation.Server.ControlPanel/Models/Connection.cs
+++ b/src/Tgstation.Server.ControlPanel/Models/Connection.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 using Tgstation.Server.Api.Models;
 
 namespace Tgstation.Server.ControlPanel.Models

--- a/src/Tgstation.Server.ControlPanel/Models/Connection.cs
+++ b/src/Tgstation.Server.ControlPanel/Models/Connection.cs
@@ -7,7 +7,7 @@ namespace Tgstation.Server.ControlPanel.Models
 	public sealed class Connection
 	{
 		[JsonIgnore]
-		public bool Valid => Url?.Host != null && !String.IsNullOrWhiteSpace(Username) && !String.IsNullOrEmpty(Credentials.Password);
+		public bool Valid => Url?.Host != null && !string.IsNullOrWhiteSpace(Username) && !string.IsNullOrEmpty(Credentials.Password);
 
 		public string Username { get; set; }
 

--- a/src/Tgstation.Server.ControlPanel/Models/Credentials.cs
+++ b/src/Tgstation.Server.ControlPanel/Models/Credentials.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Security.Cryptography;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace Tgstation.Server.ControlPanel.Models
 {
@@ -17,7 +17,7 @@ namespace Tgstation.Server.ControlPanel.Models
 			set => Encrypt(value);
 		}
 
-        public byte[] CipherText
+		public byte[] CipherText
 		{
 			get => AllowSavingPassword ? cipherText : null;
 			set => cipherText = value;
@@ -25,7 +25,7 @@ namespace Tgstation.Server.ControlPanel.Models
 
 		public byte[] Entropy { get; set; }
 
-        byte[] cipherText;
+		byte[] cipherText;
 
 		void Encrypt(string cleartext)
 		{
@@ -51,7 +51,7 @@ namespace Tgstation.Server.ControlPanel.Models
 				CipherText = clearTextBytes;
 			}
 		}
-		
+
 		public string Decrypt()
 		{
 			if (cipherText == null)

--- a/src/Tgstation.Server.ControlPanel/Models/Credentials.cs
+++ b/src/Tgstation.Server.ControlPanel/Models/Credentials.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
 using Newtonsoft.Json;
 
 namespace Tgstation.Server.ControlPanel.Models
 {
+	[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Handled for linux deployments")]
 	public class Credentials
 	{
 		[JsonIgnore]
@@ -27,6 +29,7 @@ namespace Tgstation.Server.ControlPanel.Models
 
 		byte[] cipherText;
 
+		
 		void Encrypt(string cleartext)
 		{
 			if (cleartext == null)

--- a/src/Tgstation.Server.ControlPanel/Models/Credentials.cs
+++ b/src/Tgstation.Server.ControlPanel/Models/Credentials.cs
@@ -17,17 +17,15 @@ namespace Tgstation.Server.ControlPanel.Models
 			set => Encrypt(value);
 		}
 
-#pragma warning disable CA1819 // Properties should not return arrays
-		public byte[] CipherText
+        public byte[] CipherText
 		{
 			get => AllowSavingPassword ? cipherText : null;
 			set => cipherText = value;
 		}
 
 		public byte[] Entropy { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
 
-		byte[] cipherText;
+        byte[] cipherText;
 
 		void Encrypt(string cleartext)
 		{

--- a/src/Tgstation.Server.ControlPanel/Models/UserSettings.cs
+++ b/src/Tgstation.Server.ControlPanel/Models/UserSettings.cs
@@ -4,10 +4,8 @@ namespace Tgstation.Server.ControlPanel.Models
 {
 	public sealed class UserSettings
 	{
-#pragma warning disable CA2227 // Collection properties should be read only
-		public List<Connection> Connections { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public List<Connection> Connections { get; set; }
 
-		public Credentials GitHubToken { get; set; }
+        public Credentials GitHubToken { get; set; }
 	}
 }

--- a/src/Tgstation.Server.ControlPanel/Models/UserSettings.cs
+++ b/src/Tgstation.Server.ControlPanel/Models/UserSettings.cs
@@ -4,8 +4,8 @@ namespace Tgstation.Server.ControlPanel.Models
 {
 	public sealed class UserSettings
 	{
-        public List<Connection> Connections { get; set; }
+		public List<Connection> Connections { get; set; }
 
-        public Credentials GitHubToken { get; set; }
+		public Credentials GitHubToken { get; set; }
 	}
 }

--- a/src/Tgstation.Server.ControlPanel/NotificationUpdater.cs
+++ b/src/Tgstation.Server.ControlPanel/NotificationUpdater.cs
@@ -27,7 +27,7 @@ namespace Tgstation.Server.ControlPanel
 			var productHeaderValue = new ProductHeaderValue(assemblyName.Name, assemblyName.Version.ToString());
 			var client = new GitHubClient(productHeaderValue);
 			var release = await client.Repository.Release.GetLatest("tgstation", "Tgstation.Server.ControlPanel");
-			var versionString = release.TagName.Substring("Tgstation.Server.ControlPanel-v".Length) + ".0";
+			var versionString = release.TagName["Tgstation.Server.ControlPanel-v".Length..] + ".0";
 			if (Version.TryParse(versionString, out var version))
 				return version;
 			return null;

--- a/src/Tgstation.Server.ControlPanel/NotificationUpdater.cs
+++ b/src/Tgstation.Server.ControlPanel/NotificationUpdater.cs
@@ -1,7 +1,7 @@
-﻿using Octokit;
-using System;
+﻿using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using Octokit;
 
 namespace Tgstation.Server.ControlPanel
 {

--- a/src/Tgstation.Server.ControlPanel/Program.cs
+++ b/src/Tgstation.Server.ControlPanel/Program.cs
@@ -1,6 +1,6 @@
-﻿using Avalonia;
+﻿using System.Linq;
+using Avalonia;
 using Avalonia.ReactiveUI;
-using System.Linq;
 
 namespace Tgstation.Server.ControlPanel
 {

--- a/src/Tgstation.Server.ControlPanel/UserExtensions.cs
+++ b/src/Tgstation.Server.ControlPanel/UserExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Tgstation.Server.Api.Models;
+﻿using Tgstation.Server.Api.Models;
 
 namespace Tgstation.Server.ControlPanel
 {

--- a/src/Tgstation.Server.ControlPanel/ViewLocator.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewLocator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Tgstation.Server.ControlPanel.ViewModels;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddChatBotViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddChatBotViewModel.cs
@@ -74,7 +74,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				this.RaisePropertyChanged(nameof(IrcUsingPassword));
 				if (!IrcUsingPassword)
 				{
-					IrcPassword = String.Empty;
+					IrcPassword = string.Empty;
 					this.RaisePropertyChanged(nameof(IrcPassword));
 				}
 				Add.Recheck();
@@ -172,13 +172,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			{
 				AddChatBotCommand.Close => true,
 				AddChatBotCommand.Add => !loading
-					&& !String.IsNullOrEmpty(BotName)
+					&& !string.IsNullOrEmpty(BotName)
 					&& rightsProvider.ChatBotRights.HasFlag(ChatBotRights.Create)
-					&& ((DiscordSelected && !String.IsNullOrEmpty(DiscordBotToken))
-						|| (IrcSelected && !String.IsNullOrEmpty(IrcServer)
-						&& !String.IsNullOrEmpty(IrcNick)
+					&& ((DiscordSelected && !string.IsNullOrEmpty(DiscordBotToken))
+						|| (IrcSelected && !string.IsNullOrEmpty(IrcServer)
+						&& !string.IsNullOrEmpty(IrcNick)
 						&& (!IrcUsingPassword 
-						|| !String.IsNullOrEmpty(IrcPassword)))),
+						|| !string.IsNullOrEmpty(IrcPassword)))),
 				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
 			};
 		}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddChatBotViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddChatBotViewModel.cs
@@ -1,8 +1,8 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client.Components;
@@ -27,7 +27,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public EnumCommand<AddChatBotCommand> Close { get; }
 		public EnumCommand<AddChatBotCommand> Add { get; }
-		
+
 		public ChatProvider Provider
 		{
 			get => provider;
@@ -177,7 +177,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					&& ((DiscordSelected && !string.IsNullOrEmpty(DiscordBotToken))
 						|| (IrcSelected && !string.IsNullOrEmpty(IrcServer)
 						&& !string.IsNullOrEmpty(IrcNick)
-						&& (!IrcUsingPassword 
+						&& (!IrcUsingPassword
 						|| !string.IsNullOrEmpty(IrcPassword)))),
 				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
 			};

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddGroupViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddGroupViewModel.cs
@@ -8,95 +8,92 @@ using Tgstation.Server.Client;
 
 namespace Tgstation.Server.ControlPanel.ViewModels
 {
-	sealed class AddGroupViewModel : ViewModelBase, ITreeNode, ICommandReceiver<AddGroupViewModel.AddGroupCommand>
-	{
-		public enum AddGroupCommand
-		{
-			Add,
-			Close
-		}
+    sealed class AddGroupViewModel : ViewModelBase, ITreeNode, ICommandReceiver<AddGroupViewModel.AddGroupCommand>
+    {
+        public enum AddGroupCommand
+        {
+            Add,
+            Close
+        }
 
-		public string Title => "Add Group";
+        public string Title => "Add Group";
 
-		public string Icon => "resm:Tgstation.Server.ControlPanel.Assets.plus.jpg";
+        public string Icon => "resm:Tgstation.Server.ControlPanel.Assets.plus.jpg";
 
-		public bool IsExpanded { get; set; }
+        public bool IsExpanded { get; set; }
 
-		public IReadOnlyList<ITreeNode> Children => null;
+        public IReadOnlyList<ITreeNode> Children => null;
 
-		public string GroupName
-		{
-			get => groupName;
-			set
-			{
-				this.RaiseAndSetIfChanged(ref groupName, value);
-				Add.Recheck();
-			}
-		}
+        public string GroupName
+        {
+            get => groupName;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref groupName, value);
+                Add.Recheck();
+            }
+        }
 
-		public EnumCommand<AddGroupCommand> Add { get; }
-		public EnumCommand<AddGroupCommand> Close { get; }
+        public EnumCommand<AddGroupCommand> Add { get; }
+        public EnumCommand<AddGroupCommand> Close { get; }
 
-		readonly PageContextViewModel pageContext;
-		readonly ServerInformation serverInformation;
-		readonly IUserGroupsClient groupsClient;
-		readonly IUserRightsProvider userRightsProvider;
-		readonly UserGroupRootViewModel userGroupRootViewModel;
+        readonly PageContextViewModel pageContext;
+        readonly ServerInformation serverInformation;
+        readonly IUserGroupsClient groupsClient;
+        readonly IUserRightsProvider userRightsProvider;
+        readonly UserGroupRootViewModel userGroupRootViewModel;
 
-		string groupName;
+        string groupName;
 
-		public AddGroupViewModel(PageContextViewModel pageContext, ServerInformation serverInformation, IUserGroupsClient groupsClient, IUserRightsProvider userRightsProvider, UserGroupRootViewModel userGroupRootViewModel)
-		{
-			this.pageContext = pageContext ?? throw new ArgumentNullException(nameof(pageContext));
-			this.serverInformation = serverInformation ?? throw new ArgumentNullException(nameof(serverInformation));
-			this.groupsClient = groupsClient ?? throw new ArgumentNullException(nameof(groupsClient));
-			this.userRightsProvider = userRightsProvider ?? throw new ArgumentNullException(nameof(userRightsProvider));
-			this.userGroupRootViewModel = userGroupRootViewModel ?? throw new ArgumentNullException(nameof(userGroupRootViewModel));
+        public AddGroupViewModel(PageContextViewModel pageContext, ServerInformation serverInformation, IUserGroupsClient groupsClient, IUserRightsProvider userRightsProvider, UserGroupRootViewModel userGroupRootViewModel)
+        {
+            this.pageContext = pageContext ?? throw new ArgumentNullException(nameof(pageContext));
+            this.serverInformation = serverInformation ?? throw new ArgumentNullException(nameof(serverInformation));
+            this.groupsClient = groupsClient ?? throw new ArgumentNullException(nameof(groupsClient));
+            this.userRightsProvider = userRightsProvider ?? throw new ArgumentNullException(nameof(userRightsProvider));
+            this.userGroupRootViewModel = userGroupRootViewModel ?? throw new ArgumentNullException(nameof(userGroupRootViewModel));
 
-			Add = new EnumCommand<AddGroupCommand>(AddGroupCommand.Add, this);
-			Close = new EnumCommand<AddGroupCommand>(AddGroupCommand.Close, this);
+            Add = new EnumCommand<AddGroupCommand>(AddGroupCommand.Add, this);
+            Close = new EnumCommand<AddGroupCommand>(AddGroupCommand.Close, this);
 
-			GroupName = String.Empty;
-		}
+            GroupName = string.Empty;
+        }
 
-		public Task HandleClick(CancellationToken cancellationToken)
-		{
-			pageContext.ActiveObject = this;
-			return Task.CompletedTask;
-		}
+        public Task HandleClick(CancellationToken cancellationToken)
+        {
+            pageContext.ActiveObject = this;
+            return Task.CompletedTask;
+        }
 
-		public bool CanRunCommand(AddGroupCommand command)
-		{
-			switch (command)
-			{
-				case AddGroupCommand.Add:
-					return userRightsProvider.AdministrationRights.HasFlag(Api.Rights.AdministrationRights.WriteUsers) && !String.IsNullOrWhiteSpace(GroupName);
-				case AddGroupCommand.Close:
-					return true;
-			}
+        public bool CanRunCommand(AddGroupCommand command)
+        {
+            return command switch
+            {
+                AddGroupCommand.Add => userRightsProvider.AdministrationRights.HasFlag(Api.Rights.AdministrationRights.WriteUsers) && !string.IsNullOrWhiteSpace(GroupName),
+                AddGroupCommand.Close => true,
+                _ => false,
+            };
+        }
 
-			return false;
-		}
+        public async Task RunCommand(AddGroupCommand command, CancellationToken cancellationToken)
+        {
+            switch (command)
+            {
+                case AddGroupCommand.Add:
+                    var group = await groupsClient.Create(new UserGroup
+                    {
+                        Name = GroupName,
+                    },
+                    cancellationToken);
 
-		public async Task RunCommand(AddGroupCommand command, CancellationToken cancellationToken)
-		{
-			switch (command)
-			{
-				case AddGroupCommand.Add:
-					var group = await groupsClient.Create(new UserGroup
-					{
-						Name = GroupName,
-					},
-					cancellationToken);
+                    GroupName = string.Empty;
 
-					GroupName = String.Empty;
-
-					userGroupRootViewModel.DirectAdd(group);
-					break;
-				case AddGroupCommand.Close:
-					pageContext.ActiveObject = null;
-					break;
-			}
-		}
-	}
+                    userGroupRootViewModel.DirectAdd(group);
+                    break;
+                case AddGroupCommand.Close:
+                    pageContext.ActiveObject = null;
+                    break;
+            }
+        }
+    }
 }

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddGroupViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddGroupViewModel.cs
@@ -1,99 +1,99 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Client;
 
 namespace Tgstation.Server.ControlPanel.ViewModels
 {
-    sealed class AddGroupViewModel : ViewModelBase, ITreeNode, ICommandReceiver<AddGroupViewModel.AddGroupCommand>
-    {
-        public enum AddGroupCommand
-        {
-            Add,
-            Close
-        }
+	sealed class AddGroupViewModel : ViewModelBase, ITreeNode, ICommandReceiver<AddGroupViewModel.AddGroupCommand>
+	{
+		public enum AddGroupCommand
+		{
+			Add,
+			Close
+		}
 
-        public string Title => "Add Group";
+		public string Title => "Add Group";
 
-        public string Icon => "resm:Tgstation.Server.ControlPanel.Assets.plus.jpg";
+		public string Icon => "resm:Tgstation.Server.ControlPanel.Assets.plus.jpg";
 
-        public bool IsExpanded { get; set; }
+		public bool IsExpanded { get; set; }
 
-        public IReadOnlyList<ITreeNode> Children => null;
+		public IReadOnlyList<ITreeNode> Children => null;
 
-        public string GroupName
-        {
-            get => groupName;
-            set
-            {
-                this.RaiseAndSetIfChanged(ref groupName, value);
-                Add.Recheck();
-            }
-        }
+		public string GroupName
+		{
+			get => groupName;
+			set
+			{
+				this.RaiseAndSetIfChanged(ref groupName, value);
+				Add.Recheck();
+			}
+		}
 
-        public EnumCommand<AddGroupCommand> Add { get; }
-        public EnumCommand<AddGroupCommand> Close { get; }
+		public EnumCommand<AddGroupCommand> Add { get; }
+		public EnumCommand<AddGroupCommand> Close { get; }
 
-        readonly PageContextViewModel pageContext;
-        readonly ServerInformation serverInformation;
-        readonly IUserGroupsClient groupsClient;
-        readonly IUserRightsProvider userRightsProvider;
-        readonly UserGroupRootViewModel userGroupRootViewModel;
+		readonly PageContextViewModel pageContext;
+		readonly ServerInformation serverInformation;
+		readonly IUserGroupsClient groupsClient;
+		readonly IUserRightsProvider userRightsProvider;
+		readonly UserGroupRootViewModel userGroupRootViewModel;
 
-        string groupName;
+		string groupName;
 
-        public AddGroupViewModel(PageContextViewModel pageContext, ServerInformation serverInformation, IUserGroupsClient groupsClient, IUserRightsProvider userRightsProvider, UserGroupRootViewModel userGroupRootViewModel)
-        {
-            this.pageContext = pageContext ?? throw new ArgumentNullException(nameof(pageContext));
-            this.serverInformation = serverInformation ?? throw new ArgumentNullException(nameof(serverInformation));
-            this.groupsClient = groupsClient ?? throw new ArgumentNullException(nameof(groupsClient));
-            this.userRightsProvider = userRightsProvider ?? throw new ArgumentNullException(nameof(userRightsProvider));
-            this.userGroupRootViewModel = userGroupRootViewModel ?? throw new ArgumentNullException(nameof(userGroupRootViewModel));
+		public AddGroupViewModel(PageContextViewModel pageContext, ServerInformation serverInformation, IUserGroupsClient groupsClient, IUserRightsProvider userRightsProvider, UserGroupRootViewModel userGroupRootViewModel)
+		{
+			this.pageContext = pageContext ?? throw new ArgumentNullException(nameof(pageContext));
+			this.serverInformation = serverInformation ?? throw new ArgumentNullException(nameof(serverInformation));
+			this.groupsClient = groupsClient ?? throw new ArgumentNullException(nameof(groupsClient));
+			this.userRightsProvider = userRightsProvider ?? throw new ArgumentNullException(nameof(userRightsProvider));
+			this.userGroupRootViewModel = userGroupRootViewModel ?? throw new ArgumentNullException(nameof(userGroupRootViewModel));
 
-            Add = new EnumCommand<AddGroupCommand>(AddGroupCommand.Add, this);
-            Close = new EnumCommand<AddGroupCommand>(AddGroupCommand.Close, this);
+			Add = new EnumCommand<AddGroupCommand>(AddGroupCommand.Add, this);
+			Close = new EnumCommand<AddGroupCommand>(AddGroupCommand.Close, this);
 
-            GroupName = string.Empty;
-        }
+			GroupName = string.Empty;
+		}
 
-        public Task HandleClick(CancellationToken cancellationToken)
-        {
-            pageContext.ActiveObject = this;
-            return Task.CompletedTask;
-        }
+		public Task HandleClick(CancellationToken cancellationToken)
+		{
+			pageContext.ActiveObject = this;
+			return Task.CompletedTask;
+		}
 
-        public bool CanRunCommand(AddGroupCommand command)
-        {
-            return command switch
-            {
-                AddGroupCommand.Add => userRightsProvider.AdministrationRights.HasFlag(Api.Rights.AdministrationRights.WriteUsers) && !string.IsNullOrWhiteSpace(GroupName),
-                AddGroupCommand.Close => true,
-                _ => false,
-            };
-        }
+		public bool CanRunCommand(AddGroupCommand command)
+		{
+			return command switch
+			{
+				AddGroupCommand.Add => userRightsProvider.AdministrationRights.HasFlag(Api.Rights.AdministrationRights.WriteUsers) && !string.IsNullOrWhiteSpace(GroupName),
+				AddGroupCommand.Close => true,
+				_ => false,
+			};
+		}
 
-        public async Task RunCommand(AddGroupCommand command, CancellationToken cancellationToken)
-        {
-            switch (command)
-            {
-                case AddGroupCommand.Add:
-                    var group = await groupsClient.Create(new UserGroup
-                    {
-                        Name = GroupName,
-                    },
-                    cancellationToken);
+		public async Task RunCommand(AddGroupCommand command, CancellationToken cancellationToken)
+		{
+			switch (command)
+			{
+				case AddGroupCommand.Add:
+					var group = await groupsClient.Create(new UserGroup
+					{
+						Name = GroupName,
+					},
+					cancellationToken);
 
-                    GroupName = string.Empty;
+					GroupName = string.Empty;
 
-                    userGroupRootViewModel.DirectAdd(group);
-                    break;
-                case AddGroupCommand.Close:
-                    pageContext.ActiveObject = null;
-                    break;
-            }
-        }
-    }
+					userGroupRootViewModel.DirectAdd(group);
+					break;
+				case AddGroupCommand.Close:
+					pageContext.ActiveObject = null;
+					break;
+			}
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceUserViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceUserViewModel.cs
@@ -56,7 +56,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 			users = userProvider.GetUsers()?.Where(x => x.Id != userProvider.CurrentUser.Id).ToList();
 			groups = userProvider.GetGroups()?.Where(x => x.Id != userProvider.CurrentUser.Group?.Id).ToList();
-			var userStrings = users?.Select(x => String.Format(CultureInfo.InvariantCulture, "User {0} ({1})", x.Name, x.Id)).ToList() ?? new List<string>();
+			var userStrings = users?.Select(x => string.Format(CultureInfo.InvariantCulture, "User {0} ({1})", x.Name, x.Id)).ToList() ?? new List<string>();
 			userStrings.AddRange(groups?.Select(x => $"Group {x.Name} ({x.Id})") ?? Enumerable.Empty<string>());
 			if (userStrings.Count > 0)
 				UserStrings = userStrings;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceUserViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceUserViewModel.cs
@@ -60,7 +60,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			userStrings.AddRange(groups?.Select(x => $"Group {x.Name} ({x.Id})") ?? Enumerable.Empty<string>());
 			if (userStrings.Count > 0)
 				UserStrings = userStrings;
-				
+
 			rightsProvider.OnUpdated += (a, b) => Add.Recheck();
 
 			Close = new EnumCommand<AddInstanceUserCommand>(AddInstanceUserCommand.Close, this);

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceViewModel.cs
@@ -1,10 +1,10 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Client;
 
@@ -88,13 +88,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(AddInstanceCommand command)
 		{
-            return command switch
-            {
-                AddInstanceCommand.Close => true,
-                AddInstanceCommand.Add => !adding && !string.IsNullOrWhiteSpace(Name) && !string.IsNullOrWhiteSpace(Path),
-                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
-            };
-        }
+			return command switch
+			{
+				AddInstanceCommand.Close => true,
+				AddInstanceCommand.Add => !adding && !string.IsNullOrWhiteSpace(Name) && !string.IsNullOrWhiteSpace(Path),
+				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+			};
+		}
 
 		public async Task RunCommand(AddInstanceCommand command, CancellationToken cancellationToken)
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceViewModel.cs
@@ -31,7 +31,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			get => name;
 			set
 			{
-				var simpleMode = Path.StartsWith(DefaultInstancePath, StringComparison.Ordinal) == true && Path.EndsWith(name ?? String.Empty, StringComparison.Ordinal) == true;
+				var simpleMode = Path.StartsWith(DefaultInstancePath, StringComparison.Ordinal) == true && Path.EndsWith(name ?? string.Empty, StringComparison.Ordinal) == true;
 				this.RaiseAndSetIfChanged(ref name, value);
 				if (simpleMode)
 					Path = DefaultInstancePath + name;
@@ -39,7 +39,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			}
 		}
 
-		public string ValidPaths => serverInformation.ValidInstancePaths?.Any() == true ? $"\"{String.Join("\", \"", serverInformation.ValidInstancePaths)}\"" : "Anywhere!";
+		public string ValidPaths => serverInformation.ValidInstancePaths?.Any() == true ? $"\"{string.Join("\", \"", serverInformation.ValidInstancePaths)}\"" : "Anywhere!";
 
 		public string Path
 		{
@@ -77,7 +77,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			Add = new EnumCommand<AddInstanceCommand>(AddInstanceCommand.Add, this);
 
 			Path = serverInformation.ValidInstancePaths?.FirstOrDefault() ?? DefaultInstancePath;
-			Name = String.Empty;
+			Name = string.Empty;
 		}
 
 		public Task HandleClick(CancellationToken cancellationToken)
@@ -93,7 +93,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				case AddInstanceCommand.Close:
 					return true;
 				case AddInstanceCommand.Add:
-					return !adding && !String.IsNullOrWhiteSpace(Name) && !String.IsNullOrWhiteSpace(Path);
+					return !adding && !string.IsNullOrWhiteSpace(Name) && !string.IsNullOrWhiteSpace(Path);
 				default:
 					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");
 			}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddInstanceViewModel.cs
@@ -88,16 +88,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(AddInstanceCommand command)
 		{
-			switch (command)
-			{
-				case AddInstanceCommand.Close:
-					return true;
-				case AddInstanceCommand.Add:
-					return !adding && !string.IsNullOrWhiteSpace(Name) && !string.IsNullOrWhiteSpace(Path);
-				default:
-					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");
-			}
-		}
+            return command switch
+            {
+                AddInstanceCommand.Close => true,
+                AddInstanceCommand.Add => !adding && !string.IsNullOrWhiteSpace(Name) && !string.IsNullOrWhiteSpace(Path),
+                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+            };
+        }
 
 		public async Task RunCommand(AddInstanceCommand command, CancellationToken cancellationToken)
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddStaticItemViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddStaticItemViewModel.cs
@@ -33,7 +33,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public string Title => "Add Item";
 
-		public string DetailTitle => String.Format(CultureInfo.InvariantCulture, "{0} in {1}", Title, parent.Path);
+		public string DetailTitle => string.Format(CultureInfo.InvariantCulture, "{0} in {1}", Title, parent.Path);
 
 		public string Icon => "resm:Tgstation.Server.ControlPanel.Assets.plus.jpg";
 
@@ -156,12 +156,12 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					{
 						return !Refreshing
 							&& rightsProvider.ConfigurationRights.HasFlag(ConfigurationRights.Write)
-							&& !String.IsNullOrEmpty(ItemName)
+							&& !string.IsNullOrEmpty(ItemName)
 							&& !ItemName.Contains("/")
 							&& !ItemName.Contains("\\")
 							&& (Type == ItemType.Folder
-							|| ((String.IsNullOrWhiteSpace(ItemText) ^ String.IsNullOrWhiteSpace(ItemPath))
-							&& (String.IsNullOrEmpty(ItemPath) || File.Exists(ItemPath))));
+							|| ((string.IsNullOrWhiteSpace(ItemText) ^ string.IsNullOrWhiteSpace(ItemPath))
+							&& (string.IsNullOrEmpty(ItemPath) || File.Exists(ItemPath))));
 					}
 					catch (IOException)
 					{
@@ -182,7 +182,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				case AddStaticItemCommand.Browse:
 					var ofd = new OpenFileDialog
 					{
-						Title = String.Format(CultureInfo.InvariantCulture, "Upload to {0}", ItemName),
+						Title = string.Format(CultureInfo.InvariantCulture, "Upload to {0}", ItemName),
 						InitialFileName = ItemName,
 						AllowMultiple = false
 					};
@@ -195,7 +195,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					ErrorMessage = null;
 					try
 					{
-						var newPath = (parent.Path != "/" ? parent.Path : String.Empty) + '/' + ItemName;
+						var newPath = (parent.Path != "/" ? parent.Path : string.Empty) + '/' + ItemName;
 						ConfigurationFile file;
 						if (Type == ItemType.Folder)
 						{
@@ -225,9 +225,9 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						}
 						parent.DirectAdd(file);
 
-						ItemPath = String.Empty;
-						ItemText = String.Empty;
-						ItemName = String.Empty;
+						ItemPath = string.Empty;
+						ItemText = string.Empty;
+						ItemName = string.Empty;
 					}
 					catch (ClientException e)
 					{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddStaticItemViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddStaticItemViewModel.cs
@@ -1,14 +1,14 @@
-﻿using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;
@@ -186,7 +186,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						InitialFileName = ItemName,
 						AllowMultiple = false
 					};
-					if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime) {
+					if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
+					{
 						ItemPath = (await ofd.ShowAsync(lifetime.MainWindow).ConfigureAwait(true))[0] ?? ItemPath;
 					}
 					break;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddUserViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddUserViewModel.cs
@@ -92,10 +92,10 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public Task HandleClick(CancellationToken cancellationToken)
 		{
-			Username = String.Empty;
-			Password = String.Empty;
-			ConfirmPassword = String.Empty;
-			SystemIdentifier = String.Empty;
+			Username = string.Empty;
+			Password = string.Empty;
+			ConfirmPassword = string.Empty;
+			SystemIdentifier = string.Empty;
 			pageContext.ActiveObject = this;
 			return Task.CompletedTask;
 		}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AddUserViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AddUserViewModel.cs
@@ -1,9 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Client;
 
@@ -21,7 +21,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		public bool IsExpanded { get; set; }
 
 		public string Icon => "resm:Tgstation.Server.ControlPanel.Assets.plus.jpg";
-		
+
 		public string Username
 		{
 			get => username;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/AdministrationViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/AdministrationViewModel.cs
@@ -1,11 +1,10 @@
-﻿using Avalonia.Controls;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;
@@ -29,7 +28,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		}
 
 		public string Title => model?.LatestVersion > tgsVersion && userRightsProvider.AdministrationRights.HasFlag(AdministrationRights.ChangeVersion) ? "Administration (Update Available)" : "Administration";
-		
+
 		public bool IsExpanded { get; set; }
 		public string Icon
 		{
@@ -155,7 +154,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 				model = await modelTask.ConfigureAwait(true);
 			}
-			catch(ClientException e)
+			catch (ClientException e)
 			{
 				ErrorMessage = e.Message;
 			}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/BasicNode.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/BasicNode.cs
@@ -1,7 +1,7 @@
-﻿using ReactiveUI;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 
 namespace Tgstation.Server.ControlPanel.ViewModels
 {

--- a/src/Tgstation.Server.ControlPanel/ViewModels/BitmapConverter.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/BitmapConverter.cs
@@ -1,9 +1,9 @@
-﻿using Avalonia;
+﻿using System;
+using System.Globalization;
+using Avalonia;
 using Avalonia.Data.Converters;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using System;
-using System.Globalization;
 
 namespace Tgstation.Server.ControlPanel.ViewModels
 {

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ByondViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ByondViewModel.cs
@@ -1,8 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -10,6 +6,10 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client.Components;
@@ -302,7 +302,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						InitialFileName = Path.GetFileName(ByondZipPath),
 						Filters = new List<FileDialogFilter>
 						{
-							new FileDialogFilter 
+							new FileDialogFilter
 							{
 								Name = "Zip Files",
 								Extensions = new List<string>
@@ -312,7 +312,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 							}
 						}
 					};
-					if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime) {
+					if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
+					{
 						ByondZipPath = (await ofd.ShowAsync(lifetime.MainWindow).ConfigureAwait(true))[0] ?? ByondZipPath;
 					}
 					break;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ByondViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ByondViewModel.cs
@@ -35,7 +35,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public string CurrentVersion => data != null ? FormatByondVersion(data) : "Unknown";
 
-		public string ApplyText => String.IsNullOrWhiteSpace(ByondZipPath) ?
+		public string ApplyText => string.IsNullOrWhiteSpace(ByondZipPath) ?
 			InstalledVersions
 				.Select(x => Version.Parse(x))
 				.Any(x => x.Major == NewMajor && x.Minor == NewMinor)
@@ -185,8 +185,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		static string FormatByondVersion(Byond byond) => byond.Version == null ? "None" :
 			byond.Version.Build > 0
-				? String.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", byond.Version.Major, byond.Version.Minor, byond.Version.Build)
-				: String.Format(CultureInfo.InvariantCulture, "{0}.{1}", byond.Version.Major, byond.Version.Minor);
+				? string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", byond.Version.Major, byond.Version.Minor, byond.Version.Build)
+				: string.Format(CultureInfo.InvariantCulture, "{0}.{1}", byond.Version.Major, byond.Version.Minor);
 
 		async Task Load(CancellationToken cancellationToken)
 		{
@@ -241,7 +241,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			{
 				ByondCommand.Refresh => !Refreshing && (CanRead || CanList),
 				ByondCommand.Update => !Refreshing
-				&& ((CanInstall && String.IsNullOrWhiteSpace(ByondZipPath)
+				&& ((CanInstall && string.IsNullOrWhiteSpace(ByondZipPath)
 				&& (Prebuild == 0 || InstalledVersions
 					.Select(x => Version.Parse(x))
 					.Any(x => x == new Version(NewMajor, NewMinor, Prebuild))))
@@ -266,7 +266,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					try
 					{
 						Stream zipStream = null;
-						if (!String.IsNullOrWhiteSpace(ByondZipPath))
+						if (!string.IsNullOrWhiteSpace(ByondZipPath))
 							zipStream = new FileStream(ByondZipPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete, 8192, true);
 						using (zipStream)
 						{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ChatBotViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ChatBotViewModel.cs
@@ -1,9 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client.Components;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ChatBotViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ChatBotViewModel.cs
@@ -179,7 +179,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					var update = new ChatBot
 					{
 						Id = ChatBot.Id,
-						ConnectionString = CanConnectionString && !String.IsNullOrEmpty(NewConnectionString) && NewConnectionString != ChatBot.ConnectionString ? NewConnectionString : null,
+						ConnectionString = CanConnectionString && !string.IsNullOrEmpty(NewConnectionString) && NewConnectionString != ChatBot.ConnectionString ? NewConnectionString : null,
 						ChannelLimit = CanChannelLimit ? (ushort?)NewChannelLimit : null,
 						Enabled = CanEnable && ChatBot.Enabled != NewEnabled ? (bool?)NewEnabled : null
 					};

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ChatChannelViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ChatChannelViewModel.cs
@@ -90,7 +90,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			get => Model.Tag;
 			set
 			{
-				if(string.IsNullOrEmpty(value))
+				if (string.IsNullOrEmpty(value))
 					Model.Tag = null;
 				else
 					Model.Tag = value;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ChatChannelViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ChatChannelViewModel.cs
@@ -62,9 +62,9 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 				var key = Model.IrcChannel?.Split(';').Skip(1).LastOrDefault();
 				Model.IrcChannel = value;
-				if (!String.IsNullOrWhiteSpace(key))
+				if (!string.IsNullOrWhiteSpace(key))
 					Model.IrcChannel += ';' + key;
-				BadForm = String.IsNullOrEmpty(Model.IrcChannel) || Model.IrcChannel[0] != '#';
+				BadForm = string.IsNullOrEmpty(Model.IrcChannel) || Model.IrcChannel[0] != '#';
 				Modified = true;
 				onEdit();
 			}
@@ -77,8 +77,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			{
 				if (!IsIrc)
 					return;
-				Model.IrcChannel = Model.IrcChannel?.Split(';').First() ?? String.Empty;
-				if (!String.IsNullOrWhiteSpace(value))
+				Model.IrcChannel = Model.IrcChannel?.Split(';').First() ?? string.Empty;
+				if (!string.IsNullOrWhiteSpace(value))
 					Model.IrcChannel += $";{value}";
 				Modified = true;
 				onEdit();
@@ -90,7 +90,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			get => Model.Tag;
 			set
 			{
-				if(String.IsNullOrEmpty(value))
+				if(string.IsNullOrEmpty(value))
 					Model.Tag = null;
 				else
 					Model.Tag = value;
@@ -105,7 +105,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			{
 				if (!IsDiscord)
 					return;
-				if (UInt64.TryParse(value, out var result))
+				if (ulong.TryParse(value, out var result))
 				{
 					Model.DiscordChannelId = result;
 					BadForm = false;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ChatRootViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ChatRootViewModel.cs
@@ -1,9 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client.Components;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/CompileJobViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/CompileJobViewModel.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 	{
 		public CompileJob CompileJob { get; }
 
-		public string User => String.Format(CultureInfo.InvariantCulture, "{0} ({1})", CompileJob.Job.StartedBy.Name, CompileJob.Job.StartedBy.Id);
+		public string User => string.Format(CultureInfo.InvariantCulture, "{0} ({1})", CompileJob.Job.StartedBy.Name, CompileJob.Job.StartedBy.Id);
 
 		public string StoppedAt => CompileJob.Job.StoppedAt.Value.ToLocalTime().ToString("g");
 

--- a/src/Tgstation.Server.ControlPanel/ViewModels/CompileJobViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/CompileJobViewModel.cs
@@ -1,8 +1,8 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 
 namespace Tgstation.Server.ControlPanel.ViewModels

--- a/src/Tgstation.Server.ControlPanel/ViewModels/CompilerViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/CompilerViewModel.cs
@@ -1,9 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client.Components;
@@ -166,7 +166,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		readonly IDreamMakerClient dreamMakerClient;
 		readonly IInstanceJobSink jobSink;
 		readonly IInstanceUserRightsProvider rightsProvider;
-		
+
 		readonly Dictionary<int, IReadOnlyList<CompileJobViewModel>> jobPages;
 
 		IReadOnlyList<CompileJob> jobIds;
@@ -179,7 +179,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		string newDme;
 		int newPort;
-		
+
 		bool refreshing;
 		bool apiRequire;
 		bool autoDetectDme;
@@ -264,13 +264,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				async Task AssignModel() => Model = await (CanRead ? dreamMakerClient.Read(cancellationToken) : Task.FromResult<DreamMaker>(null)).ConfigureAwait(true);
 
 				var readTask = AssignModel();
-				
+
 				var jobsTask = CanGetJobs ? dreamMakerClient.ListCompileJobs(new Client.PaginationSettings
 				{
 					PageSize = 100,
 					RetrieveCount = 500
 				}, cancellationToken) : Task.FromResult<IReadOnlyList<CompileJob>>(null);
-				
+
 				jobIds = (await jobsTask.ConfigureAwait(true)).OfType<CompileJob>().ToList();
 				numPages = (jobIds.Count / JobsPerPage) + (jobIds.Count > JobsPerPage && ((jobIds.Count % JobsPerPage) > 0) ? 1 : 0);
 				this.RaisePropertyChanged(nameof(ViewNumPages));

--- a/src/Tgstation.Server.ControlPanel/ViewModels/CompilerViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/CompilerViewModel.cs
@@ -122,7 +122,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			{
 				this.RaiseAndSetIfChanged(ref autoDetectDme, value);
 				if (value)
-					NewDme = String.Empty;
+					NewDme = string.Empty;
 				this.RaisePropertyChanged(nameof(CanDmeView));
 				Update.Recheck();
 			}
@@ -242,7 +242,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		void ResetFields()
 		{
-			NewDme = String.Empty;
+			NewDme = string.Empty;
 			NewPort = 0;
 			AutoDetectDme = Model?.ProjectName == null;
 			newSecurityLevel = Model?.ApiValidationSecurityLevel ?? DreamDaemonSecurity.Safe;
@@ -327,7 +327,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				CompilerCommand.Update => !Refreshing
 					&& (CanPort || CanDme || CanSecurity)
 					//either a new dme name is set, or the checkbox is different than the model
-					&& (!String.IsNullOrEmpty(NewDme) || (AutoDetectDme ^ (Model?.ProjectName == null))
+					&& (!string.IsNullOrEmpty(NewDme) || (AutoDetectDme ^ (Model?.ProjectName == null))
 					|| NewPort != 0
 					|| newSecurityLevel != Model?.ApiValidationSecurityLevel
 					|| ApiRequire != (Model?.RequireDMApiValidation ?? true)),
@@ -375,10 +375,10 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					{
 						var newModel = new DreamMaker();
 						if (CanDme)
-							if (!String.IsNullOrEmpty(NewDme))
+							if (!string.IsNullOrEmpty(NewDme))
 								newModel.ProjectName = NewDme;
 							else if (AutoDetectDme)
-								newModel.ProjectName = String.Empty;
+								newModel.ProjectName = string.Empty;
 
 						if (CanRequire)
 							newModel.RequireDMApiValidation = ApiRequire;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
@@ -507,17 +507,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(ConnectionManagerCommand command)
 		{
-			switch (command)
-			{
-				case ConnectionManagerCommand.Delete:
-				case ConnectionManagerCommand.Close:
-					return true;
-				case ConnectionManagerCommand.Connect:
-					return connection.Valid && !Connecting;
-				default:
-					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");
-			}
-		}
+            return command switch
+            {
+                ConnectionManagerCommand.Delete or ConnectionManagerCommand.Close => true,
+                ConnectionManagerCommand.Connect => connection.Valid && !Connecting,
+                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+            };
+        }
 
 		public async Task RunCommand(ConnectionManagerCommand command, CancellationToken cancellationToken)
 		{
@@ -534,7 +530,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					{
 						async void DeleteConfirmTimeout()
 						{
-							await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+							await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken).ConfigureAwait(false);
 							confirmingDelete = false;
 							this.RaisePropertyChanged(nameof(DeleteWord));
 						}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
@@ -27,7 +27,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		const string HttpPrefix = "http://";
 		const string HttpsPrefix = "https://";
 
-		public string Title => String.Format(CultureInfo.InvariantCulture, "{0} ({1})", connection.Url, userVM == null ? connection.Username : userVM.User.Name);
+		public string Title => string.Format(CultureInfo.InvariantCulture, "{0} ({1})", connection.Url, userVM == null ? connection.Username : userVM.User.Name);
 		public bool IsExpanded {
 			get => isExpanded;
 			set => this.RaiseAndSetIfChanged(ref isExpanded, value);
@@ -120,7 +120,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 				try
 				{
-					connection.Url = new Uri(String.Concat(usingHttp ? HttpPrefix : HttpsPrefix, connection.Url.ToString().Remove(0, usingHttp ? HttpsPrefix.Length : HttpPrefix.Length)));
+					connection.Url = new Uri(string.Concat(usingHttp ? HttpPrefix : HttpsPrefix, connection.Url.ToString().Remove(0, usingHttp ? HttpsPrefix.Length : HttpPrefix.Length)));
 					this.RaisePropertyChanged(nameof(ServerAddress));
 					this.RaisePropertyChanged(nameof(Title));
 					Connect.Recheck();
@@ -166,7 +166,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 							Password = User.DefaultAdminPassword;
 						}
 						else
-							Password = String.Empty;
+							Password = string.Empty;
 						Connect.Recheck();
 					}
 				}
@@ -329,11 +329,11 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				{
 					serverInfo = await serverClient.ServerInformation(cancellationToken).ConfigureAwait(false);
 					
-					versionNode.Title = String.Format(CultureInfo.InvariantCulture, "{0}: {1}", versionNode.Title, serverInfo.Version);
-					apiVersionNode.Title = String.Format(CultureInfo.InvariantCulture, "{0}: {1}", apiVersionNode.Title, serverInfo.ApiVersion);
-					dmapiVersionNode.Title = String.Format(CultureInfo.InvariantCulture, "{0}: {1}", dmapiVersionNode.Title, serverInfo.DMApiVersion);
-					instanceLimitNode.Title = String.Format(CultureInfo.InvariantCulture, "{0}: {1}", instanceLimitNode.Title, serverInfo.InstanceLimit);
-					userLimitNode.Title = String.Format(CultureInfo.InvariantCulture, "{0}: {1}", userLimitNode.Title, serverInfo.UserLimit);
+					versionNode.Title = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", versionNode.Title, serverInfo.Version);
+					apiVersionNode.Title = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", apiVersionNode.Title, serverInfo.ApiVersion);
+					dmapiVersionNode.Title = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", dmapiVersionNode.Title, serverInfo.DMApiVersion);
+					instanceLimitNode.Title = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", instanceLimitNode.Title, serverInfo.InstanceLimit);
+					userLimitNode.Title = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", userLimitNode.Title, serverInfo.UserLimit);
 					fakeSwarmNode.Title = $"Swarm: {(serverInfo.SwarmServers == null ? "Disabled" : $"{serverInfo.SwarmServers.Count} Servers")}";
 					versionNode.Icon = InfoIcon;
 					apiVersionNode.Icon = InfoIcon;
@@ -461,13 +461,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				ConnectionFailed = true;
 				this.RaisePropertyChanged(nameof(ConnectionFailed));
 
-				ErrorMessage = String.Format(CultureInfo.InvariantCulture, "{0} (HTTP {1})", e.Message, e.ResponseMessage.StatusCode);
+				ErrorMessage = string.Format(CultureInfo.InvariantCulture, "{0} (HTTP {1})", e.Message, e.ResponseMessage.StatusCode);
 			}
 			catch (HttpRequestException e)
 			{
 				ConnectionFailed = true;
 				this.RaisePropertyChanged(nameof(ConnectionFailed));
-				ErrorMessage = String.Format(CultureInfo.InvariantCulture, "An HTTP error occurred: {0}", (e.InnerException ?? e).Message);
+				ErrorMessage = string.Format(CultureInfo.InvariantCulture, "An HTTP error occurred: {0}", (e.InnerException ?? e).Message);
 			}
 			finally
 			{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
@@ -1,11 +1,11 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Client;
 using Tgstation.Server.ControlPanel.Models;
@@ -28,7 +28,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		const string HttpsPrefix = "https://";
 
 		public string Title => string.Format(CultureInfo.InvariantCulture, "{0} ({1})", connection.Url, userVM == null ? connection.Username : userVM.User.Name);
-		public bool IsExpanded {
+		public bool IsExpanded
+		{
 			get => isExpanded;
 			set => this.RaiseAndSetIfChanged(ref isExpanded, value);
 		}
@@ -209,7 +210,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		public EnumCommand<ConnectionManagerCommand> Delete { get; }
 
 		readonly Connection connection;
-		
+
 		readonly IServerClientFactory serverClientFactory;
 		readonly IRequestLogger requestLogger;
 
@@ -328,7 +329,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				try
 				{
 					serverInfo = await serverClient.ServerInformation(cancellationToken).ConfigureAwait(false);
-					
+
 					versionNode.Title = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", versionNode.Title, serverInfo.Version);
 					apiVersionNode.Title = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", apiVersionNode.Title, serverInfo.ApiVersion);
 					dmapiVersionNode.Title = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", dmapiVersionNode.Title, serverInfo.DMApiVersion);
@@ -507,13 +508,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(ConnectionManagerCommand command)
 		{
-            return command switch
-            {
-                ConnectionManagerCommand.Delete or ConnectionManagerCommand.Close => true,
-                ConnectionManagerCommand.Connect => connection.Valid && !Connecting,
-                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
-            };
-        }
+			return command switch
+			{
+				ConnectionManagerCommand.Delete or ConnectionManagerCommand.Close => true,
+				ConnectionManagerCommand.Connect => connection.Valid && !Connecting,
+				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+			};
+		}
 
 		public async Task RunCommand(ConnectionManagerCommand command, CancellationToken cancellationToken)
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/DreamDaemonViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/DreamDaemonViewModel.cs
@@ -1,10 +1,10 @@
-﻿using Avalonia.Media;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Media;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client.Components;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/DreamDaemonViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/DreamDaemonViewModel.cs
@@ -340,7 +340,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				NewPrimaryPort = Model.Port ?? 0;
 				NewAutoStart = Model.AutoStart ?? false;
 				NewAllowWebClient = Model.AllowWebClient ?? false;
-				NewAdditionalParams = Model.AdditionalParameters ?? String.Empty;
+				NewAdditionalParams = Model.AdditionalParameters ?? string.Empty;
 				initalSecurityLevel = Model.SecurityLevel;
 
 				ClearSoft = true;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/EnumCommand.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/EnumCommand.cs
@@ -1,7 +1,6 @@
-﻿using Avalonia.Threading;
-using System;
-using System.Globalization;
+﻿using System;
 using System.Windows.Input;
+using Avalonia.Threading;
 
 namespace Tgstation.Server.ControlPanel.ViewModels
 {

--- a/src/Tgstation.Server.ControlPanel/ViewModels/IInstanceUserRightsProvider.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/IInstanceUserRightsProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Tgstation.Server.Api.Rights;
+﻿using Tgstation.Server.Api.Rights;
 
 namespace Tgstation.Server.ControlPanel.ViewModels
 {
@@ -14,6 +13,6 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		DreamDaemonRights DreamDaemonRights { get; }
 		ChatBotRights ChatBotRights { get; }
 		ConfigurationRights ConfigurationRights { get; }
-		
+
 	}
 }

--- a/src/Tgstation.Server.ControlPanel/ViewModels/InstanceRootViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/InstanceRootViewModel.cs
@@ -1,9 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/InstanceUserRootViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/InstanceUserRootViewModel.cs
@@ -1,10 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client.Components;
@@ -60,7 +59,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			rightsProvider.OnUpdated += (a, b) => InitialLoad();
 		}
 
-		public static string GetDisplayNameForInstanceUser(IUserProvider userProvider, InstancePermissionSet user) {
+		public static string GetDisplayNameForInstanceUser(IUserProvider userProvider, InstancePermissionSet user)
+		{
 			var actualUser = userProvider
 				.GetUsers()
 				?.Where(x => x.GetPermissionSet().Id == user.PermissionSetId)
@@ -89,7 +89,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			var nullPage = true;
 			try
 			{
-				if(rightsProvider.InstanceUserRights == InstancePermissionSetRights.None)
+				if (rightsProvider.InstanceUserRights == InstancePermissionSetRights.None)
 				{
 					Children = null;
 					Icon = "resm:Tgstation.Server.ControlPanel.Assets.denied.jpg";
@@ -110,7 +110,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				if (rightsProvider.InstanceUserRights.HasFlag(InstancePermissionSetRights.Create))
 					newChildren.Add(new AddInstanceUserViewModel(pageContext, this, instanceUserClient, rightsProvider, userProvider));
 
-				if(hasReadRight)
+				if (hasReadRight)
 					newChildren.AddRange(activeUsers
 						.Select(x => new InstanceUserViewModel(pageContext, instanceViewModel, rightsProvider, instanceUserClient, x,
 						GetDisplayNameForInstanceUser(userProvider, x),

--- a/src/Tgstation.Server.ControlPanel/ViewModels/InstanceUserViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/InstanceUserViewModel.cs
@@ -1,8 +1,8 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client.Components;
@@ -939,14 +939,14 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(InstanceUserCommand command)
 		{
-            return command switch
-            {
-                InstanceUserCommand.Close => true,
-                InstanceUserCommand.Refresh => !loading,
-                InstanceUserCommand.Save or InstanceUserCommand.Delete => rightsProvider.InstanceUserRights.HasFlag(InstancePermissionSetRights.Write) && !loading,
-                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
-            };
-        }
+			return command switch
+			{
+				InstanceUserCommand.Close => true,
+				InstanceUserCommand.Refresh => !loading,
+				InstanceUserCommand.Save or InstanceUserCommand.Delete => rightsProvider.InstanceUserRights.HasFlag(InstancePermissionSetRights.Write) && !loading,
+				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+			};
+		}
 
 		public async Task RunCommand(InstanceUserCommand command, CancellationToken cancellationToken)
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/InstanceUserViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/InstanceUserViewModel.cs
@@ -939,19 +939,14 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(InstanceUserCommand command)
 		{
-			switch (command)
-			{
-				case InstanceUserCommand.Close:
-					return true;
-				case InstanceUserCommand.Refresh:
-					return !loading;
-				case InstanceUserCommand.Save:
-				case InstanceUserCommand.Delete:
-					return rightsProvider.InstanceUserRights.HasFlag(InstancePermissionSetRights.Write) && !loading;
-				default:
-					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");
-			}
-		}
+            return command switch
+            {
+                InstanceUserCommand.Close => true,
+                InstanceUserCommand.Refresh => !loading,
+                InstanceUserCommand.Save or InstanceUserCommand.Delete => rightsProvider.InstanceUserRights.HasFlag(InstancePermissionSetRights.Write) && !loading,
+                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+            };
+        }
 
 		public async Task RunCommand(InstanceUserCommand command, CancellationToken cancellationToken)
 		{
@@ -1002,7 +997,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 						async void ResetConfirm()
 						{
-							await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(true);
+							await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken).ConfigureAwait(true);
 							confirmingDelete = false;
 							this.RaisePropertyChanged(nameof(DeleteText));
 						}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/InstanceViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/InstanceViewModel.cs
@@ -185,8 +185,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				ConfigMode = Instance.ConfigurationType.Value;
 				AutoUpdateInterval = Instance.AutoUpdateInterval.Value;
 				NewChatBotLimit = Instance.ChatBotLimit.Value;
-				NewName = String.Empty;
-				NewPath = String.Empty;
+				NewName = string.Empty;
+				NewPath = string.Empty;
 
 				if (!Enabled)
 					return;
@@ -321,9 +321,9 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						{
 							Id = Instance.Id
 						};
-						if (!String.IsNullOrWhiteSpace(NewName) && CanRename)
+						if (!string.IsNullOrWhiteSpace(NewName) && CanRename)
 							newInstance.Name = NewName;
-						if (!String.IsNullOrWhiteSpace(NewPath) && CanRelocate)
+						if (!string.IsNullOrWhiteSpace(NewPath) && CanRelocate)
 							newInstance.Path = NewPath;
 						if (CanOnline)
 							newInstance.Online = Enabled;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/InstanceViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/InstanceViewModel.cs
@@ -251,19 +251,14 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(InstanceCommand command)
 		{
-			switch (command)
-			{
-				case InstanceCommand.Close:
-					return true;
-				case InstanceCommand.Save:
-				case InstanceCommand.FixPerms:
-					return !loading;
-				case InstanceCommand.Delete:
-					return userRightsProvider.InstanceManagerRights.HasFlag(InstanceManagerRights.Delete);
-				default:
-					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");
-			}
-		}
+            return command switch
+            {
+                InstanceCommand.Close => true,
+                InstanceCommand.Save or InstanceCommand.FixPerms => !loading,
+                InstanceCommand.Delete => userRightsProvider.InstanceManagerRights.HasFlag(InstanceManagerRights.Delete),
+                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+            };
+        }
 		public async Task Refresh(CancellationToken cancellationToken)
 		{
 			loading = true;
@@ -341,7 +336,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						{
 							async void ResetDelete()
 							{
-								await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(true);
+								await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken).ConfigureAwait(true);
 								deleteConfirming = false;
 								this.RaisePropertyChanged(nameof(DeleteText));
 							}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/InstanceViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/InstanceViewModel.cs
@@ -1,8 +1,8 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;
@@ -167,10 +167,10 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				{
 					instanceJobSink = await serverJobSink?.GetSinkForInstance(instanceClient, default) ?? throw new ArgumentNullException(nameof(serverJobSink));
 				}
-				catch (InsufficientPermissionsException) { }	//we won't be needing it
+				catch (InsufficientPermissionsException) { }    //we won't be needing it
 			await PostRefresh(default).ConfigureAwait(true);
 		}
-	
+
 		public void SetDDRunning(bool yes)
 		{
 			ddRunning = yes;
@@ -215,7 +215,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			var instanceUserTreeNode = new InstanceUserViewModel(pageContext, this, userRightsProvider, instanceClient.PermissionSets, instanceUser, InstanceUserRootViewModel.GetDisplayNameForInstanceUser(userProvider, instanceUser), null, null, userProvider.CurrentUser.Group != null);
 
 			instanceUserTreeNode.OnUpdated += (a, b) => SafeLoad(null);
-			
+
 			var newChildren = new List<ITreeNode>
 			{
 				instanceUserTreeNode,
@@ -251,14 +251,14 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(InstanceCommand command)
 		{
-            return command switch
-            {
-                InstanceCommand.Close => true,
-                InstanceCommand.Save or InstanceCommand.FixPerms => !loading,
-                InstanceCommand.Delete => userRightsProvider.InstanceManagerRights.HasFlag(InstanceManagerRights.Delete),
-                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
-            };
-        }
+			return command switch
+			{
+				InstanceCommand.Close => true,
+				InstanceCommand.Save or InstanceCommand.FixPerms => !loading,
+				InstanceCommand.Delete => userRightsProvider.InstanceManagerRights.HasFlag(InstanceManagerRights.Delete),
+				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+			};
+		}
 		public async Task Refresh(CancellationToken cancellationToken)
 		{
 			loading = true;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/JobManagerViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/JobManagerViewModel.cs
@@ -1,7 +1,7 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Client;
 

--- a/src/Tgstation.Server.ControlPanel/ViewModels/JobViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/JobViewModel.cs
@@ -74,16 +74,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(JobCommand command)
 		{
-			switch (command)
-			{
-				case JobCommand.Remove:
-					return Finished;
-				case JobCommand.Cancel:
-					return canCancel && !Finished && jobsClient != null;
-				default:
-					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");
-			}
-		}
+            return command switch
+            {
+                JobCommand.Remove => Finished,
+                JobCommand.Cancel => canCancel && !Finished && jobsClient != null,
+                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+            };
+        }
 
 		public async Task RunCommand(JobCommand command, CancellationToken cancellationToken)
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/JobViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/JobViewModel.cs
@@ -18,7 +18,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			Cancel
 		}
 
-		public string Title => String.Format(CultureInfo.InvariantCulture, "Job #{0}", job.Id) + (Finished ? (Cancelled ? " (Cancelled)" : Error ? " (Failed)" : " (Done)") : String.Empty);
+		public string Title => string.Format(CultureInfo.InvariantCulture, "Job #{0}", job.Id) + (Finished ? (Cancelled ? " (Cancelled)" : Error ? " (Failed)" : " (Done)") : string.Empty);
 
 		public bool Finished => job.StoppedAt.HasValue;
 		public bool Error => job.ExceptionDetails != null;
@@ -31,7 +31,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public string Description => job.Description;
 
-		public string StartedBy => String.Format(CultureInfo.InvariantCulture, "{0} ({1})", job.StartedBy.Name, job.StartedBy.Id);
+		public string StartedBy => string.Format(CultureInfo.InvariantCulture, "{0} ({1})", job.StartedBy.Name, job.StartedBy.Id);
 		public string StartedAt => job.StartedAt.Value.ToLocalTime().ToString("g");
 
 		public bool Cancelled => job.Cancelled == true;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/JobViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/JobViewModel.cs
@@ -1,9 +1,9 @@
-﻿using Avalonia.Media;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Media;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Client;
 using Tgstation.Server.Client.Components;
@@ -74,13 +74,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(JobCommand command)
 		{
-            return command switch
-            {
-                JobCommand.Remove => Finished,
-                JobCommand.Cancel => canCancel && !Finished && jobsClient != null,
-                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
-            };
-        }
+			return command switch
+			{
+				JobCommand.Remove => Finished,
+				JobCommand.Cancel => canCancel && !Finished && jobsClient != null,
+				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+			};
+		}
 
 		public async Task RunCommand(JobCommand command, CancellationToken cancellationToken)
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/LogFileViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/LogFileViewModel.cs
@@ -71,7 +71,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					{
 						var fullLogTuple = await administrationClient.GetLog(logFile, cancellationToken);
 						using var fileStream = new FileStream(savePath, FileMode.Create);
-						await fullLogTuple.Item2.CopyToAsync(fileStream);
+						await fullLogTuple.Item2.CopyToAsync(fileStream, cancellationToken);
 					}
 				}
 			}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/LogFileViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/LogFileViewModel.cs
@@ -1,11 +1,11 @@
-﻿using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;
@@ -65,7 +65,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			Working = true;
 			try
 			{
-				if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime) {
+				if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
+				{
 					var savePath = await sfd.ShowAsync(lifetime.MainWindow).ConfigureAwait(true);
 					if (Directory.Exists(System.IO.Path.GetDirectoryName(savePath)))
 					{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/MainWindowViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/MainWindowViewModel.cs
@@ -37,7 +37,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		readonly ProductHeaderValue productHeaderValue;
 
-		public static string Versions => String.Format(CultureInfo.InvariantCulture, "Version: {0}, API Version: {1}", Assembly.GetExecutingAssembly().GetName().Version, ApiHeaders.Version);
+		public static string Versions => string.Format(CultureInfo.InvariantCulture, "Version: {0}, API Version: {1}", Assembly.GetExecutingAssembly().GetName().Version, ApiHeaders.Version);
 
 		public static string Meme
 		{
@@ -176,7 +176,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		void GlobalExceptionHandler(Exception e)
 		{
-			var exceptionFileName = Path.Combine(storageDirectory, String.Format(CultureInfo.InvariantCulture, "crash_please_report.{0}.log", DateTimeOffset.Now.ToUnixTimeSeconds()));
+			var exceptionFileName = Path.Combine(storageDirectory, string.Format(CultureInfo.InvariantCulture, "crash_please_report.{0}.log", DateTimeOffset.Now.ToUnixTimeSeconds()));
 			File.WriteAllText(exceptionFileName, e.ToString());
 			ControlPanel.OpenFolder(storageDirectory);
 		}
@@ -186,7 +186,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				new Octokit.Connection(
 					new Octokit.ProductHeaderValue(productHeaderValue.Name, productHeaderValue.Version),
 					new HttpClientAdapter(() => new LoggingHandler(this))));
-			if (!String.IsNullOrEmpty(GitHubToken))
+			if (!string.IsNullOrEmpty(GitHubToken))
 				tmpClient.Credentials = new Octokit.Credentials(GitHubToken);
 			gitHubClient = tmpClient;
 		}
@@ -218,7 +218,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			settings.Connections ??= new List<Connection>();
 			settings.GitHubToken ??= new Credentials()
 			{
-				Password = String.Empty
+				Password = string.Empty
 			};
 			settings.GitHubToken.AllowSavingPassword = true;
 			return settings;
@@ -283,8 +283,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				if (property.PropertyType == typeof(string))
 					property.SetValue(
 						model,
-						String.Join(
-							String.Empty,
+                        string.Join(
+                            string.Empty,
 							Enumerable.Repeat(
 								'*',
 								((string)censorField).Length)));
@@ -318,10 +318,10 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public async Task LogRequest(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
 		{
-			var instancePart = String.Empty;
+			var instancePart = string.Empty;
 			if (requestMessage.Headers.TryGetValues("Instance", out var values))
-				instancePart = String.Format(CultureInfo.InvariantCulture, " I:{0}", values.First());
-			var bodyPart = String.Empty;
+				instancePart = string.Format(CultureInfo.InvariantCulture, " I:{0}", values.First());
+			var bodyPart = string.Empty;
 
 			if (requestMessage.Content is StreamContent)
 			{
@@ -329,15 +329,15 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				return;
 			}
 
-			var bodyString = await (requestMessage.Content?.ReadAsStringAsync() ?? Task.FromResult<string>(null)).ConfigureAwait(false);
-			if (!String.IsNullOrEmpty(bodyString))
+			var bodyString = await (requestMessage.Content?.ReadAsStringAsync(cancellationToken) ?? Task.FromResult<string>(null)).ConfigureAwait(false);
+			if (!string.IsNullOrEmpty(bodyString))
 			{
 				//may contain the password for some things, User models, censor it
 				CensorBodyString<UserUpdate>(x => x.Password, ref bodyString);
 				CensorBodyString<Repository>(x => x.AccessToken, ref bodyString);
 				CensorBodyString<ChatBot>(x => x.ConnectionString, ref bodyString);
 
-				bodyPart = String.Format(CultureInfo.InvariantCulture, " => {0}", bodyString);
+				bodyPart = string.Format(CultureInfo.InvariantCulture, " => {0}", bodyString);
 			}
 
 			AddToConsole($"{requestMessage.Method} {requestMessage.RequestUri}{instancePart}{bodyPart}");
@@ -346,9 +346,9 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		public async Task LogResponse(HttpResponseMessage responseMessage, CancellationToken cancellationToken)
 		{
 			var requestMessage = responseMessage.RequestMessage;
-			var instancePart = String.Empty;
+			var instancePart = string.Empty;
 			if (requestMessage.Headers.TryGetValues("Instance", out var values))
-				instancePart = String.Format(CultureInfo.InvariantCulture, " I:{0}", values.First());
+				instancePart = string.Format(CultureInfo.InvariantCulture, " I:{0}", values.First());
 
 			if (responseMessage.Content.Headers.ContentType?.MediaType == MediaTypeNames.Application.Octet)
 			{
@@ -356,22 +356,22 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				return;
 			}
 
-			var bodyString = await (responseMessage.Content?.ReadAsStringAsync() ?? Task.FromResult<string>(null)).ConfigureAwait(false);
+			var bodyString = await (responseMessage.Content?.ReadAsStringAsync(cancellationToken) ?? Task.FromResult<string>(null)).ConfigureAwait(false);
 			if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
 			{
 				var tmpFile = Path.Combine(Path.GetTempPath(), "tgs_error.html");
 				File.WriteAllText(tmpFile, bodyString);
-				ControlPanel.LaunchUrl(String.Format("file:///{0}", tmpFile));
-				bodyString = String.Format("Error page written to {0}", tmpFile);
+				ControlPanel.LaunchUrl(string.Format("file:///{0}", tmpFile));
+				bodyString = string.Format("Error page written to {0}", tmpFile);
 			}
-			var bodyPart = String.Empty;
-			if (!String.IsNullOrEmpty(bodyString))
+			var bodyPart = string.Empty;
+			if (!string.IsNullOrEmpty(bodyString))
 			{
 				CensorBodyString<Repository>(x => x.AccessToken, ref bodyString);
 				CensorBodyString<ChatBot>(x => x.ConnectionString, ref bodyString);
 				CensorBodyString<Token>(x => x.Bearer, ref bodyString);
 
-				bodyPart = String.Format(CultureInfo.InvariantCulture, " => {0}", bodyString);
+				bodyPart = string.Format(CultureInfo.InvariantCulture, " => {0}", bodyString);
 			}
 
 			AddToConsole($"HTTP {responseMessage.StatusCode}: {requestMessage.Method} {requestMessage.RequestUri}{instancePart}{bodyPart}");
@@ -385,18 +385,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(MainWindowCommand command)
 		{
-			switch (command)
-			{
-				case MainWindowCommand.NewServerConnection:
-				case MainWindowCommand.CopyConsole:
-				case MainWindowCommand.ReportIssue:
-					return true;
-				case MainWindowCommand.AppUpdate:
-					return updater.Functional && updateReady;
-				default:
-					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");
-			}
-		}
+            return command switch
+            {
+                MainWindowCommand.NewServerConnection or MainWindowCommand.CopyConsole or MainWindowCommand.ReportIssue => true,
+                MainWindowCommand.AppUpdate => updater.Functional && updateReady,
+                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+            };
+        }
 
 		public async Task RunCommand(MainWindowCommand command, CancellationToken cancellationToken)
 		{
@@ -407,9 +402,9 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					{
 						Credentials = new Credentials
 						{
-							Password = String.Empty
+							Password = string.Empty
 						},
-						Username = String.Empty,
+						Username = string.Empty,
 						Timeout = TimeSpan.FromSeconds(15),
 						JobRequeryRate = TimeSpan.FromSeconds(10),
 						Url = new Uri("https://localhost:5000")
@@ -433,7 +428,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					lock(this)
 						tmp = new List<string>(ConsoleContent.Split('\n'));
 					tmp.RemoveAt(0);    //remove info line
-					var clipboard = String.Join(" ", tmp);
+					var clipboard = string.Join(" ", tmp);
 					TextCopy.Clipboard.SetText(clipboard);
 					break;
 				case MainWindowCommand.AppUpdate:
@@ -451,8 +446,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						updater.RestartApp();
 					break;
 				case MainWindowCommand.ReportIssue:
-					var body = String.Format("<Please describe your issue here>{0}{0}{0}Console:{0}```{0}{1}{0}```{0}Reported from version {2}", Environment.NewLine, ConsoleContent, Assembly.GetExecutingAssembly().GetName().Version);
-					ControlPanel.LaunchUrl(String.Format(CultureInfo.InvariantCulture, "https://github.com/tgstation/Tgstation.Server.ControlPanel/issues/new?body={0}", HttpUtility.UrlEncode(body)));
+					var body = string.Format("<Please describe your issue here>{0}{0}{0}Console:{0}```{0}{1}{0}```{0}Reported from version {2}", Environment.NewLine, ConsoleContent, Assembly.GetExecutingAssembly().GetName().Version);
+					ControlPanel.LaunchUrl(string.Format(CultureInfo.InvariantCulture, "https://github.com/tgstation/Tgstation.Server.ControlPanel/issues/new?body={0}", HttpUtility.UrlEncode(body)));
 					break;
 				default:
 					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");

--- a/src/Tgstation.Server.ControlPanel/ViewModels/MainWindowViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/MainWindowViewModel.cs
@@ -1,9 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
-using Octokit.Internal;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -18,6 +13,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using System.Windows.Input;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Octokit.Internal;
+using ReactiveUI;
 using Tgstation.Server.Api;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Client;
@@ -283,8 +283,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				if (property.PropertyType == typeof(string))
 					property.SetValue(
 						model,
-                        string.Join(
-                            string.Empty,
+						string.Join(
+							string.Empty,
 							Enumerable.Repeat(
 								'*',
 								((string)censorField).Length)));
@@ -385,13 +385,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(MainWindowCommand command)
 		{
-            return command switch
-            {
-                MainWindowCommand.NewServerConnection or MainWindowCommand.CopyConsole or MainWindowCommand.ReportIssue => true,
-                MainWindowCommand.AppUpdate => updater.Functional && updateReady,
-                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
-            };
-        }
+			return command switch
+			{
+				MainWindowCommand.NewServerConnection or MainWindowCommand.CopyConsole or MainWindowCommand.ReportIssue => true,
+				MainWindowCommand.AppUpdate => updater.Functional && updateReady,
+				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+			};
+		}
 
 		public async Task RunCommand(MainWindowCommand command, CancellationToken cancellationToken)
 		{
@@ -425,7 +425,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					break;
 				case MainWindowCommand.CopyConsole:
 					List<string> tmp;
-					lock(this)
+					lock (this)
 						tmp = new List<string>(ConsoleContent.Split('\n'));
 					tmp.RemoveAt(0);    //remove info line
 					var clipboard = string.Join(" ", tmp);

--- a/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
@@ -1,11 +1,11 @@
-﻿using Avalonia.Media;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Media;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;
@@ -482,7 +482,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			{
 				HandleRateLimit(e);
 			}
-			catch(Exception ex)
+			catch (Exception ex)
 			{
 				MainWindowViewModel.HandleException(ex);
 			}
@@ -581,14 +581,14 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			{
 				// manual addition
 				var manualPr = new Octokit.Issue(
-                    string.Empty,
+					string.Empty,
 					$"https://github.com/{Repository.RemoteRepositoryOwner}/{Repository.RemoteRepositoryName}/pull/{number}",
-                    string.Empty,
-                    string.Empty,
+					string.Empty,
+					string.Empty,
 					number,
 					Octokit.ItemState.Open,
 					"Unable to Load PR Details",
-                    string.Empty,
+					string.Empty,
 					null,
 					new Octokit.User(),
 					Array.Empty<Octokit.Label>(),
@@ -601,7 +601,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					default,
 					null,
 					0,
-                    string.Empty,
+					string.Empty,
 					false,
 					null,
 					null);
@@ -643,23 +643,23 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(RepositoryCommand command)
 		{
-            return command switch
-            {
-                RepositoryCommand.Close => true,
-                RepositoryCommand.Refresh => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.Read),
-                RepositoryCommand.Update => !Refreshing
-                    && (CanAutoUpdate | CanChangeCommitter | CanAccess | CanShowTMCommitters | CanTestMerge | CanSetRef | CanSetSha | CanUpdate)
-                    && !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken)),
-                RepositoryCommand.Delete => !Refreshing && CanDelete,
-                RepositoryCommand.Clone => !Refreshing 
-                    && CanClone && !string.IsNullOrEmpty(NewOrigin) 
-                    && Uri.TryCreate(NewOrigin, UriKind.Absolute, out var _)
-                    && !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken)),
-                RepositoryCommand.RemoveCredentials => !Refreshing && CanAccess,
-                RepositoryCommand.DirectAddPR or RepositoryCommand.RefreshPRs => !Refreshing && CanTestMerge && !RateLimited && !loadingPRs,
-                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
-            };
-        }
+			return command switch
+			{
+				RepositoryCommand.Close => true,
+				RepositoryCommand.Refresh => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.Read),
+				RepositoryCommand.Update => !Refreshing
+					&& (CanAutoUpdate | CanChangeCommitter | CanAccess | CanShowTMCommitters | CanTestMerge | CanSetRef | CanSetSha | CanUpdate)
+					&& !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken)),
+				RepositoryCommand.Delete => !Refreshing && CanDelete,
+				RepositoryCommand.Clone => !Refreshing
+					&& CanClone && !string.IsNullOrEmpty(NewOrigin)
+					&& Uri.TryCreate(NewOrigin, UriKind.Absolute, out var _)
+					&& !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken)),
+				RepositoryCommand.RemoveCredentials => !Refreshing && CanAccess,
+				RepositoryCommand.DirectAddPR or RepositoryCommand.RefreshPRs => !Refreshing && CanTestMerge && !RateLimited && !loadingPRs,
+				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+			};
+		}
 
 		public async Task RunCommand(RepositoryCommand command, CancellationToken cancellationToken)
 		{
@@ -706,7 +706,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						// Wait until the job has progress
 						if (job != null)
 						{
-							while(!job.StoppedAt.HasValue && !job.Progress.HasValue)
+							while (!job.StoppedAt.HasValue && !job.Progress.HasValue)
 							{
 								await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
 								job = await jobsClient.GetId(job, cancellationToken).ConfigureAwait(false);

--- a/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
@@ -137,18 +137,18 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					this.RaisePropertyChanged(nameof(CanSetRef));
 					if (value)
 					{
-						if (String.IsNullOrEmpty(NewReference) && Repository != null)
+						if (string.IsNullOrEmpty(NewReference) && Repository != null)
 							NewReference = Repository.Reference;
-						NewSha = String.Empty;
+						NewSha = string.Empty;
 					}
 					else if (NewReference == Repository?.Reference)
-						NewReference = String.Empty;
+						NewReference = string.Empty;
 					RebuildTestMergeList();
 				}
 			}
 		}
 
-		public bool CanUpdateMerge => !UpdateHard && String.IsNullOrEmpty(NewReference) && String.IsNullOrEmpty(NewSha);
+		public bool CanUpdateMerge => !UpdateHard && string.IsNullOrEmpty(NewReference) && string.IsNullOrEmpty(NewSha);
 
 		public bool NewShowTestMergeCommitters
 		{
@@ -191,8 +191,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanClone => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.SetOrigin);
 		public bool CanDelete => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.Delete);
-		public bool CanSetRef => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.SetReference) && String.IsNullOrEmpty(NewSha) && !UpdateHard;
-		public bool CanSetSha => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.SetSha) && String.IsNullOrEmpty(NewReference);
+		public bool CanSetRef => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.SetReference) && string.IsNullOrEmpty(NewSha) && !UpdateHard;
+		public bool CanSetSha => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.SetSha) && string.IsNullOrEmpty(NewReference);
 		public bool CanShowTMCommitters => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.ChangeTestMergeCommits);
 		public bool CanChangeCommitter => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.ChangeCommitter);
 		public bool CanAccess => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.ChangeCredentials);
@@ -220,7 +220,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			set => this.RaiseAndSetIfChanged(ref refreshing, value);
 		}
 
-		public string UpdateText => String.IsNullOrEmpty(NewSha) && (String.IsNullOrEmpty(NewReference) || NewReference == Repository.Reference) ? "Fetch and Hard Reset To Tracked Origin Reference" : "Fetch and Hard Reset to Target Origin Object";
+		public string UpdateText => string.IsNullOrEmpty(NewSha) && (string.IsNullOrEmpty(NewReference) || NewReference == Repository.Reference) ? "Fetch and Hard Reset To Tracked Origin Reference" : "Fetch and Hard Reset to Target Origin Object";
 
 		public string ErrorMessage
 		{
@@ -400,13 +400,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 					Repository = newRepo;
 
-					NewOrigin = String.Empty;
-					NewSha = String.Empty;
-					NewReference = String.Empty;
-					NewCommitterEmail = String.Empty;
-					NewCommitterName = String.Empty;
-					NewAccessUser = String.Empty;
-					NewAccessToken = String.Empty;
+					NewOrigin = string.Empty;
+					NewSha = string.Empty;
+					NewReference = string.Empty;
+					NewCommitterEmail = string.Empty;
+					NewCommitterName = string.Empty;
+					NewAccessUser = string.Empty;
+					NewAccessToken = string.Empty;
 
 					UpdateHard = false;
 					UpdateMerge = false;
@@ -581,14 +581,14 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			{
 				// manual addition
 				var manualPr = new Octokit.Issue(
-					String.Empty,
+                    string.Empty,
 					$"https://github.com/{Repository.RemoteRepositoryOwner}/{Repository.RemoteRepositoryName}/pull/{number}",
-					String.Empty,
-					String.Empty,
+                    string.Empty,
+                    string.Empty,
 					number,
 					Octokit.ItemState.Open,
 					"Unable to Load PR Details",
-					String.Empty,
+                    string.Empty,
 					null,
 					new Octokit.User(),
 					Array.Empty<Octokit.Label>(),
@@ -601,7 +601,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					default,
 					null,
 					0,
-					String.Empty,
+                    string.Empty,
 					false,
 					null,
 					null);
@@ -620,7 +620,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		void HandleRateLimit(Octokit.RateLimitExceededException e)
 		{
 			RateLimited = true;
-			void UpdateSeconds() => RateLimitSeconds = String.Format(CultureInfo.InvariantCulture, "You have been rate limited by GitHub, add a personal access token on the Connection Manager to increase the limit. This will reset in {0}s...", Math.Floor((e.Reset - DateTimeOffset.Now).TotalSeconds));
+			void UpdateSeconds() => RateLimitSeconds = string.Format(CultureInfo.InvariantCulture, "You have been rate limited by GitHub, add a personal access token on the Connection Manager to increase the limit. This will reset in {0}s...", Math.Floor((e.Reset - DateTimeOffset.Now).TotalSeconds));
 			UpdateSeconds();
 			async void ResetRate()
 			{
@@ -652,11 +652,11 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				case RepositoryCommand.Update:
 					return !Refreshing
 						&& (CanAutoUpdate | CanChangeCommitter | CanAccess | CanShowTMCommitters | CanTestMerge | CanSetRef | CanSetSha | CanUpdate)
-						&& !(!String.IsNullOrEmpty(NewAccessUser) ^ !String.IsNullOrEmpty(NewAccessToken));
+						&& !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken));
 				case RepositoryCommand.Delete:
 					return !Refreshing && CanDelete;
 				case RepositoryCommand.Clone:
-					return !Refreshing && CanClone && !String.IsNullOrEmpty(NewOrigin) && Uri.TryCreate(NewOrigin, UriKind.Absolute, out var _) && !(!String.IsNullOrEmpty(NewAccessUser) ^ !String.IsNullOrEmpty(NewAccessToken));
+					return !Refreshing && CanClone && !string.IsNullOrEmpty(NewOrigin) && Uri.TryCreate(NewOrigin, UriKind.Absolute, out var _) && !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken));
 				case RepositoryCommand.RemoveCredentials:
 					return !Refreshing && CanAccess;
 				case RepositoryCommand.DirectAddPR:
@@ -680,12 +680,12 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				case RepositoryCommand.Update:
 					var update = new Repository
 					{
-						CheckoutSha = String.IsNullOrEmpty(NewSha) ? null : NewSha,
-						Reference = String.IsNullOrEmpty(NewReference) ? null : NewReference,
+						CheckoutSha = string.IsNullOrEmpty(NewSha) ? null : NewSha,
+						Reference = string.IsNullOrEmpty(NewReference) ? null : NewReference,
 						UpdateFromOrigin = UpdateHard || UpdateMerge ? (bool?)true : null,
 
-						AccessToken = String.IsNullOrEmpty(NewAccessToken) ? null : NewAccessToken,
-						AccessUser = String.IsNullOrEmpty(NewAccessUser) ? null : NewAccessUser,
+						AccessToken = string.IsNullOrEmpty(NewAccessToken) ? null : NewAccessToken,
+						AccessUser = string.IsNullOrEmpty(NewAccessUser) ? null : NewAccessUser,
 
 						AutoUpdatesKeepTestMerges = CanAutoUpdate ? (bool?)NewAutoUpdatesKeepTestMerges : null,
 						AutoUpdatesSynchronize = CanAutoUpdate ? (bool?)NewAutoUpdatesSynchronize : null,
@@ -694,8 +694,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						ShowTestMergeCommitters = CanShowTMCommitters ? (bool?)NewShowTestMergeCommitters : null,
 						CreateGitHubDeployments = CanShowTMCommitters ? (bool?)NewGitHubDeployments : null,
 
-						CommitterEmail = !String.IsNullOrEmpty(NewCommitterEmail) ? NewCommitterEmail : null,
-						CommitterName = !String.IsNullOrEmpty(NewCommitterName) ? NewCommitterName : null
+						CommitterEmail = !string.IsNullOrEmpty(NewCommitterEmail) ? NewCommitterEmail : null,
+						CommitterName = !string.IsNullOrEmpty(NewCommitterName) ? NewCommitterName : null
 					};
 
 					if (modifiedPRList || UpdateHard)
@@ -743,9 +743,9 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					var clone = new Repository
 					{
 						Origin = new Uri(NewOrigin),
-						Reference = String.IsNullOrEmpty(NewReference) ? null : NewReference,
-						AccessToken = String.IsNullOrEmpty(NewAccessToken) || !CanAccess ? null : NewAccessToken,
-						AccessUser = String.IsNullOrEmpty(NewAccessUser) || !CanAccess ? null : NewAccessUser,
+						Reference = string.IsNullOrEmpty(NewReference) ? null : NewReference,
+						AccessToken = string.IsNullOrEmpty(NewAccessToken) || !CanAccess ? null : NewAccessToken,
+						AccessUser = string.IsNullOrEmpty(NewAccessUser) || !CanAccess ? null : NewAccessUser,
 						RecurseSubmodules = RecurseSubmodules
 					};
 					await Refresh(clone, true, cancellationToken).ConfigureAwait(true);
@@ -753,8 +753,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				case RepositoryCommand.RemoveCredentials:
 					await Refresh(new Repository
 					{
-						AccessUser = String.Empty,
-						AccessToken = String.Empty
+						AccessUser = string.Empty,
+						AccessToken = string.Empty
 					}, null, cancellationToken).ConfigureAwait(true);
 					break;
 				case RepositoryCommand.DirectAddPR:

--- a/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
@@ -643,29 +643,23 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(RepositoryCommand command)
 		{
-			switch (command)
-			{
-				case RepositoryCommand.Close:
-					return true;
-				case RepositoryCommand.Refresh:
-					return !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.Read);
-				case RepositoryCommand.Update:
-					return !Refreshing
-						&& (CanAutoUpdate | CanChangeCommitter | CanAccess | CanShowTMCommitters | CanTestMerge | CanSetRef | CanSetSha | CanUpdate)
-						&& !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken));
-				case RepositoryCommand.Delete:
-					return !Refreshing && CanDelete;
-				case RepositoryCommand.Clone:
-					return !Refreshing && CanClone && !string.IsNullOrEmpty(NewOrigin) && Uri.TryCreate(NewOrigin, UriKind.Absolute, out var _) && !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken));
-				case RepositoryCommand.RemoveCredentials:
-					return !Refreshing && CanAccess;
-				case RepositoryCommand.DirectAddPR:
-				case RepositoryCommand.RefreshPRs:
-					return !Refreshing && CanTestMerge && !RateLimited && !loadingPRs;
-				default:
-					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");
-			}
-		}
+            return command switch
+            {
+                RepositoryCommand.Close => true,
+                RepositoryCommand.Refresh => !Refreshing && rightsProvider.RepositoryRights.HasFlag(RepositoryRights.Read),
+                RepositoryCommand.Update => !Refreshing
+                    && (CanAutoUpdate | CanChangeCommitter | CanAccess | CanShowTMCommitters | CanTestMerge | CanSetRef | CanSetSha | CanUpdate)
+                    && !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken)),
+                RepositoryCommand.Delete => !Refreshing && CanDelete,
+                RepositoryCommand.Clone => !Refreshing 
+                    && CanClone && !string.IsNullOrEmpty(NewOrigin) 
+                    && Uri.TryCreate(NewOrigin, UriKind.Absolute, out var _)
+                    && !(!string.IsNullOrEmpty(NewAccessUser) ^ !string.IsNullOrEmpty(NewAccessToken)),
+                RepositoryCommand.RemoveCredentials => !Refreshing && CanAccess,
+                RepositoryCommand.DirectAddPR or RepositoryCommand.RefreshPRs => !Refreshing && CanTestMerge && !RateLimited && !loadingPRs,
+                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+            };
+        }
 
 		public async Task RunCommand(RepositoryCommand command, CancellationToken cancellationToken)
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ServerJobSinkViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ServerJobSinkViewModel.cs
@@ -1,11 +1,11 @@
-﻿using Avalonia.Threading;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Threading;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Client;
 using Tgstation.Server.Client.Components;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/StaticFileViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/StaticFileViewModel.cs
@@ -1,14 +1,14 @@
-﻿using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;
@@ -144,7 +144,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		public EnumCommand<StaticFileCommand> BrowseDownload { get; }
 		public EnumCommand<StaticFileCommand> EnableEditor { get; }
 
-		public string Title =>  System.IO.Path.GetFileName(Path);
+		public string Title => System.IO.Path.GetFileName(Path);
 
 		public string Icon => Refreshing ? "resm:Tgstation.Server.ControlPanel.Assets.hourglass.png" : Denied ? "resm:Tgstation.Server.ControlPanel.Assets.denied.jpg" : "resm:Tgstation.Server.ControlPanel.Assets.file.png";
 
@@ -225,7 +225,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				await fileTuple.Item2.DisposeAsync();
 				DirectLoad(fileTuple.Item1);
 			}
-			catch(ClientException e)
+			catch (ClientException e)
 			{
 				ErrorMessage = e.Message;
 				Denied = e is InsufficientPermissionsException;
@@ -331,7 +331,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					await WriteGeneric(new MemoryStream(Encoding.UTF8.GetBytes(TextBlob))).ConfigureAwait(true);
 					break;
 				case StaticFileCommand.Delete:
-					if(confirmingDelete)
+					if (confirmingDelete)
 						await WriteGeneric(null).ConfigureAwait(true);
 					else
 					{
@@ -355,7 +355,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					var ext = System.IO.Path.GetExtension(Path);
 					if (!string.IsNullOrEmpty(ext))
 						sfd.DefaultExtension = ext;
-					
+
 					if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime1)
 						DownloadPath = (await sfd.ShowAsync(lifetime1.MainWindow).ConfigureAwait(true)) ?? DownloadPath;
 					break;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/StaticFileViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/StaticFileViewModel.cs
@@ -88,7 +88,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			get => textBlob;
 			set
 			{
-				this.RaiseAndSetIfChanged(ref textBlob, value.Replace("\r", String.Empty));
+				this.RaiseAndSetIfChanged(ref textBlob, value.Replace("\r", string.Empty));
 				this.RaisePropertyChanged(nameof(IsText));
 				textChanged = true;
 				Write.Recheck();
@@ -349,11 +349,11 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				case StaticFileCommand.BrowseDownload:
 					var sfd = new SaveFileDialog
 					{
-						Title = String.Format(CultureInfo.InvariantCulture, "Save {0}", Path),
+						Title = string.Format(CultureInfo.InvariantCulture, "Save {0}", Path),
 						InitialFileName = System.IO.Path.GetFileName(Path)
 					};
 					var ext = System.IO.Path.GetExtension(Path);
-					if (!String.IsNullOrEmpty(ext))
+					if (!string.IsNullOrEmpty(ext))
 						sfd.DefaultExtension = ext;
 					
 					if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime1)
@@ -362,7 +362,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				case StaticFileCommand.BrowseUpload:
 					var ofd = new OpenFileDialog
 					{
-						Title = String.Format(CultureInfo.InvariantCulture, "Upload to {0}", Path),
+						Title = string.Format(CultureInfo.InvariantCulture, "Upload to {0}", Path),
 						InitialFileName = System.IO.Path.GetFileName(Path),
 						AllowMultiple = false
 					};

--- a/src/Tgstation.Server.ControlPanel/ViewModels/StaticFileViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/StaticFileViewModel.cs
@@ -320,7 +320,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					var fileTuple = await configurationClient.Read(ConfigurationFile, cancellationToken);
 					using (fileTuple.Item2)
 					using (var fileStream = new FileStream(DownloadPath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite, 8192, true))
-						await fileTuple.Item2.CopyToAsync(fileStream).ConfigureAwait(false);
+						await fileTuple.Item2.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
 					ControlPanel.OpenFolder(System.IO.Path.GetDirectoryName(DownloadPath));
 					break;
 				case StaticFileCommand.Upload:
@@ -337,7 +337,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 					{
 						async void ResetDelete()
 						{
-							await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(true);
+							await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken).ConfigureAwait(true);
 							confirmingDelete = false;
 							this.RaisePropertyChanged(nameof(DeleteText));
 						}
@@ -382,7 +382,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						using var memoryStream = new MemoryStream();
 						var fileTuple2 = await configurationClient.Read(ConfigurationFile, cancellationToken);
 						using (fileTuple2.Item2)
-							await fileTuple2.Item2.CopyToAsync(memoryStream).ConfigureAwait(false);
+							await fileTuple2.Item2.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
 						try
 						{
 							TextBlob = Encoding.UTF8.GetString(memoryStream.ToArray());

--- a/src/Tgstation.Server.ControlPanel/ViewModels/StaticFolderViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/StaticFolderViewModel.cs
@@ -25,7 +25,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			get
 			{
 				var fileName = System.IO.Path.GetFileName(Path);
-				if (String.IsNullOrEmpty(fileName))
+				if (string.IsNullOrEmpty(fileName))
 					return "Configuration";
 				return fileName;
 			}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/StaticFolderViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/StaticFolderViewModel.cs
@@ -1,9 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;
@@ -148,7 +148,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				IsExpanded = true;
 				this.RaisePropertyChanged(nameof(IsExpanded));
 			}
-			catch(ClientException e)
+			catch (ClientException e)
 			{
 				ErrorMessage = e.Message;
 				Denied = e is InsufficientPermissionsException;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
@@ -1,12 +1,12 @@
-﻿using Avalonia.Media;
-using Octokit;
-using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Media;
+using Octokit;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 
 namespace Tgstation.Server.ControlPanel.ViewModels
@@ -79,7 +79,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		TestMergeViewModel(Action<int> onActivate)
 		{
 			this.onActivate = onActivate ?? throw new ArgumentNullException(nameof(onActivate));
-			
+
 			Link = new EnumCommand<TestMergeCommand>(TestMergeCommand.Link, this);
 			LoadCommits = new EnumCommand<TestMergeCommand>(TestMergeCommand.LoadCommits, this);
 		}
@@ -128,13 +128,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(TestMergeCommand command)
 		{
-            return command switch
-            {
-                TestMergeCommand.Link => true,
-                TestMergeCommand.LoadCommits => !CommitsLoaded,
-                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
-            };
-        }
+			return command switch
+			{
+				TestMergeCommand.Link => true,
+				TestMergeCommand.LoadCommits => !CommitsLoaded,
+				_ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+			};
+		}
 		public async Task RunCommand(TestMergeCommand command, CancellationToken cancellationToken)
 		{
 			switch (command)

--- a/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
@@ -19,9 +19,9 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			LoadCommits
 		}
 
-		public string Title => String.Format(CultureInfo.InvariantCulture, "#{0} - {1}", TestMerge.Number, TestMerge.TitleAtMerge);
+		public string Title => string.Format(CultureInfo.InvariantCulture, "#{0} - {1}", TestMerge.Number, TestMerge.TitleAtMerge);
 
-		public string MergedBy => String.Format(CultureInfo.InvariantCulture, "{0} ({1})", TestMerge.MergedBy.Name, TestMerge.MergedBy.Id);
+		public string MergedBy => string.Format(CultureInfo.InvariantCulture, "{0} ({1})", TestMerge.MergedBy.Name, TestMerge.MergedBy.Id);
 		public string MergedAt => TestMerge.MergedAt.ToLocalTime().ToString("g");
 
 		public bool Selected
@@ -119,7 +119,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		{
 			if (commits == null)
 				return;
-			Commits = commits?.Select(x => String.Format(CultureInfo.InvariantCulture, "{0} - {1}", x.Sha.Substring(0, 7), x.Commit.Message.Split('\n').First())).ToList();
+			Commits = commits?.Select(x => string.Format(CultureInfo.InvariantCulture, "{0} - {1}", x.Sha.Substring(0, 7), x.Commit.Message.Split('\n').First())).ToList();
 			this.RaisePropertyChanged(nameof(Commits));
 			this.RaisePropertyChanged(nameof(CommitsLoaded));
 			LoadCommits.Recheck();

--- a/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
@@ -128,16 +128,13 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(TestMergeCommand command)
 		{
-			switch (command)
-			{
-				case TestMergeCommand.Link:
-					return true;
-				case TestMergeCommand.LoadCommits:
-					return !CommitsLoaded;
-				default:
-					throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!");
-			}
-		}
+            return command switch
+            {
+                TestMergeCommand.Link => true,
+                TestMergeCommand.LoadCommits => !CommitsLoaded,
+                _ => throw new ArgumentOutOfRangeException(nameof(command), command, "Invalid command!"),
+            };
+        }
 		public async Task RunCommand(TestMergeCommand command, CancellationToken cancellationToken)
 		{
 			switch (command)

--- a/src/Tgstation.Server.ControlPanel/ViewModels/UserGroupRootViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/UserGroupRootViewModel.cs
@@ -1,9 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/UserGroupViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/UserGroupViewModel.cs
@@ -52,7 +52,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			}
 		}
 
-		public bool HasError => !String.IsNullOrWhiteSpace(Error);
+		public bool HasError => !string.IsNullOrWhiteSpace(Error);
 
 		public PermissionSetViewModel PermissionSetViewModel { get; private set; }
 

--- a/src/Tgstation.Server.ControlPanel/ViewModels/UserGroupViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/UserGroupViewModel.cs
@@ -153,20 +153,15 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(UserGroupsCommand command)
 		{
-			switch (command)
-			{
-				case UserGroupsCommand.AddUser:
-					return !Loading && SelectedIndex < UserStrings.Count && userProvider.GetUsers() != null && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.WriteUsers);
-				case UserGroupsCommand.Close:
-					return true;
-				case UserGroupsCommand.Delete:
-					return !Loading && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.WriteUsers) && UserCount == 0;
-				case UserGroupsCommand.Refresh:
-					return !Loading && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.ReadUsers);
-			}
-
-			return false;
-		}
+            return command switch
+            {
+                UserGroupsCommand.AddUser => !Loading && SelectedIndex < UserStrings.Count && userProvider.GetUsers() != null && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.WriteUsers),
+                UserGroupsCommand.Close => true,
+                UserGroupsCommand.Delete => !Loading && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.WriteUsers) && UserCount == 0,
+                UserGroupsCommand.Refresh => !Loading && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.ReadUsers),
+                _ => false,
+            };
+        }
 
 		List<User> GetFilteredUsers()
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/UserGroupViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/UserGroupViewModel.cs
@@ -1,9 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;
@@ -134,7 +134,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				Group = await groupsClient.GetId(Group, cancellationToken).ConfigureAwait(false);
 				UpdateUserStrings();
 			}
-			catch(Exception ex)
+			catch (Exception ex)
 			{
 				Error = ex.Message;
 			}
@@ -153,15 +153,15 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool CanRunCommand(UserGroupsCommand command)
 		{
-            return command switch
-            {
-                UserGroupsCommand.AddUser => !Loading && SelectedIndex < UserStrings.Count && userProvider.GetUsers() != null && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.WriteUsers),
-                UserGroupsCommand.Close => true,
-                UserGroupsCommand.Delete => !Loading && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.WriteUsers) && UserCount == 0,
-                UserGroupsCommand.Refresh => !Loading && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.ReadUsers),
-                _ => false,
-            };
-        }
+			return command switch
+			{
+				UserGroupsCommand.AddUser => !Loading && SelectedIndex < UserStrings.Count && userProvider.GetUsers() != null && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.WriteUsers),
+				UserGroupsCommand.Close => true,
+				UserGroupsCommand.Delete => !Loading && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.WriteUsers) && UserCount == 0,
+				UserGroupsCommand.Refresh => !Loading && rightsProvider.AdministrationRights.HasFlag(AdministrationRights.ReadUsers),
+				_ => false,
+			};
+		}
 
 		List<User> GetFilteredUsers()
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/UserViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/UserViewModel.cs
@@ -42,9 +42,9 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		public bool IsSystemUser => User.SystemIdentifier != null;
 
-		public string FormatCreatedBy => User.CreatedBy != null ? String.Format(CultureInfo.InvariantCulture, "{0} ({1})", User.CreatedBy.Name, User.CreatedBy.Id) : "TGS";
+		public string FormatCreatedBy => User.CreatedBy != null ? string.Format(CultureInfo.InvariantCulture, "{0} ({1})", User.CreatedBy.Name, User.CreatedBy.Id) : "TGS";
 
-		public string Title => String.Format(CultureInfo.InvariantCulture, "User: {0} ({1})", user.Name, user.Id);
+		public string Title => string.Format(CultureInfo.InvariantCulture, "User: {0} ({1})", user.Name, user.Id);
 
 		public string Icon => "resm:Tgstation.Server.ControlPanel.Assets.user.png";
 
@@ -139,8 +139,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			RemoveFromGroup = new EnumCommand<UserCommand>(UserCommand.RemoveFromGroup, this);
 			Save = new EnumCommand<UserCommand>(UserCommand.Save, this);
 
-			NewPassword = String.Empty;
-			PasswordConfirm = String.Empty;
+			NewPassword = string.Empty;
+			PasswordConfirm = string.Empty;
 
 			Enabled = User.Enabled.Value;
 			void SetLocks()
@@ -252,8 +252,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 			using (DelayChangeNotifications())
 			{
-				NewPassword = String.Empty;
-				PasswordConfirm = String.Empty;
+				NewPassword = string.Empty;
+				PasswordConfirm = string.Empty;
 				Refresh.Recheck();
 				Save.Recheck();
 			}

--- a/src/Tgstation.Server.ControlPanel/ViewModels/UserViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/UserViewModel.cs
@@ -1,11 +1,11 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;
@@ -127,7 +127,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		{
 			this.usersClient = usersClient ?? throw new ArgumentNullException(nameof(usersClient));
 			this.serverInformation = serverInformation ?? throw new ArgumentNullException(nameof(serverInformation));
-            this.pageContext = pageContext ?? throw new ArgumentNullException(nameof(pageContext));
+			this.pageContext = pageContext ?? throw new ArgumentNullException(nameof(pageContext));
 			this.userRightsProvider = userRightsProvider ?? this;
 
 			User = user ?? throw new ArgumentNullException(nameof(user));

--- a/src/Tgstation.Server.ControlPanel/ViewModels/UserViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/UserViewModel.cs
@@ -127,12 +127,10 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		{
 			this.usersClient = usersClient ?? throw new ArgumentNullException(nameof(usersClient));
 			this.serverInformation = serverInformation ?? throw new ArgumentNullException(nameof(serverInformation));
-			if (user == null)
-				throw new ArgumentNullException(nameof(user));
-			this.pageContext = pageContext ?? throw new ArgumentNullException(nameof(pageContext));
+            this.pageContext = pageContext ?? throw new ArgumentNullException(nameof(pageContext));
 			this.userRightsProvider = userRightsProvider ?? this;
 
-			User = user;
+			User = user ?? throw new ArgumentNullException(nameof(user));
 
 			Close = new EnumCommand<UserCommand>(UserCommand.Close, this);
 			Refresh = new EnumCommand<UserCommand>(UserCommand.Refresh, this);

--- a/src/Tgstation.Server.ControlPanel/ViewModels/UsersRootViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/UsersRootViewModel.cs
@@ -1,9 +1,9 @@
-﻿using ReactiveUI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Client;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ViewModelBase.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ViewModelBase.cs
@@ -1,37 +1,35 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using ReactiveUI;
 
 namespace Tgstation.Server.ControlPanel.ViewModels
 {
-    public class ViewModelBase : ReactiveObject
-    {
-        public bool IsSelected
+	public class ViewModelBase : ReactiveObject
+	{
+		public bool IsSelected
 		{
-            get => isSelected;
-            set
-            {
-                var wasClick = value && !isSelected;
-                isSelected = value;
-                if (wasClick)
-                    TryClick();
-            }
+			get => isSelected;
+			set
+			{
+				var wasClick = value && !isSelected;
+				isSelected = value;
+				if (wasClick)
+					TryClick();
+			}
 		}
 
-        bool isSelected;
+		bool isSelected;
 
-        async void TryClick()
-        {
-            if (this is ITreeNode treeNode)
-                try
-                {
-                    await treeNode.HandleClick(default);
-                }
-                catch (Exception ex)
-                {
-                    MainWindowViewModel.HandleException(ex);
-                }
-        }
-    }
+		async void TryClick()
+		{
+			if (this is ITreeNode treeNode)
+				try
+				{
+					await treeNode.HandleClick(default);
+				}
+				catch (Exception ex)
+				{
+					MainWindowViewModel.HandleException(ex);
+				}
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Console.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Console.xaml.cs
@@ -24,7 +24,7 @@ namespace Tgstation.Server.ControlPanel.Views
 			};
 			timer.Tick += ((sender, e) =>
 			{
-				scrollViewer.CaretIndex = Int32.MaxValue;
+				scrollViewer.CaretIndex = int.MaxValue;
 			});
 			timer.Start();
 		}

--- a/src/Tgstation.Server.ControlPanel/Views/Console.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Console.xaml.cs
@@ -1,21 +1,20 @@
-﻿using Avalonia;
+﻿using System;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
-using System;
 
 namespace Tgstation.Server.ControlPanel.Views
 {
-    public class Console : UserControl
-    {
-        public Console()
-        {
-            this.InitializeComponent();
-        }
+	public class Console : UserControl
+	{
+		public Console()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
 
 			var scrollViewer = this.FindControl<TextBox>("_scrollViewer");
 			DispatcherTimer timer = new DispatcherTimer
@@ -28,5 +27,5 @@ namespace Tgstation.Server.ControlPanel.Views
 			});
 			timer.Start();
 		}
-    }
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/JobViewer.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/JobViewer.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views
 {
-    public class JobViewer : UserControl
-    {
-        public JobViewer()
-        {
-            this.InitializeComponent();
-        }
+	public class JobViewer : UserControl
+	{
+		public JobViewer()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/MainView.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/MainView.xaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views

--- a/src/Tgstation.Server.ControlPanel/Views/MainWindow.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/MainWindow.xaml.cs
@@ -4,16 +4,16 @@ using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views
 {
-    public sealed class MainWindow : Window
-    {
-        public MainWindow()
-        {
-            InitializeComponent();
+	public sealed class MainWindow : Window
+	{
+		public MainWindow()
+		{
+			InitializeComponent();
 #if DEBUG
-            this.AttachDevTools();
+			this.AttachDevTools();
 #endif
-        }
+		}
 
-        void InitializeComponent() => AvaloniaXamlLoader.Load(this);
-    }
+		void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/ObjectBrowserItem.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/ObjectBrowserItem.xaml.cs
@@ -1,8 +1,5 @@
 ﻿using Avalonia.Controls;
-using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
-using System;
-using Tgstation.Server.ControlPanel.ViewModels;
 
 namespace Tgstation.Server.ControlPanel.Views
 {

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddChatBot.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddChatBot.xaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddInstance.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddInstance.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class AddInstance : UserControl
-    {
-        public AddInstance()
-        {
-            this.InitializeComponent();
-        }
+	public class AddInstance : UserControl
+	{
+		public AddInstance()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddInstanceUser.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddInstanceUser.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class AddInstanceUser : UserControl
-    {
-        public AddInstanceUser()
-        {
-            this.InitializeComponent();
-        }
+	public class AddInstanceUser : UserControl
+	{
+		public AddInstanceUser()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddServer.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddServer.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class AddServer : UserControl
-    {
-        public AddServer()
-        {
-            this.InitializeComponent();
-        }
+	public class AddServer : UserControl
+	{
+		public AddServer()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddUser.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddUser.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class AddUser : UserControl
-    {
-        public AddUser()
-        {
-            this.InitializeComponent();
-        }
+	public class AddUser : UserControl
+	{
+		public AddUser()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddUserGroup.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddUserGroup.xaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Administration.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Administration.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class Administration : UserControl
-    {
-        public Administration()
-        {
-            this.InitializeComponent();
-        }
+	public class Administration : UserControl
+	{
+		public Administration()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Byond.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Byond.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class Byond : UserControl
-    {
-        public Byond()
-        {
-            this.InitializeComponent();
-        }
+	public class Byond : UserControl
+	{
+		public Byond()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/ChatBot.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/ChatBot.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class ChatBot : UserControl
-    {
-        public ChatBot()
-        {
-            this.InitializeComponent();
-        }
+	public class ChatBot : UserControl
+	{
+		public ChatBot()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/CompileJobList.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/CompileJobList.xaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/DreamMaker.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/DreamMaker.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class DreamMaker : UserControl
-    {
-        public DreamMaker()
-        {
-            this.InitializeComponent();
-        }
+	public class DreamMaker : UserControl
+	{
+		public DreamMaker()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/GroupManager.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/GroupManager.xaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/InstanceManager.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/InstanceManager.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class InstanceManager : UserControl
-    {
-        public InstanceManager()
-        {
-            this.InitializeComponent();
-        }
+	public class InstanceManager : UserControl
+	{
+		public InstanceManager()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/InstanceUser.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/InstanceUser.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class InstanceUser : UserControl
-    {
-        public InstanceUser()
-        {
-            this.InitializeComponent();
-        }
+	public class InstanceUser : UserControl
+	{
+		public InstanceUser()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/PermissionSet.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/PermissionSet.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class PermissionSet : UserControl
-    {
-        public PermissionSet()
-        {
-            this.InitializeComponent();
-        }
+	public class PermissionSet : UserControl
+	{
+		public PermissionSet()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Repository.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Repository.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class Repository : UserControl
-    {
-        public Repository()
-        {
-            this.InitializeComponent();
-        }
+	public class Repository : UserControl
+	{
+		public Repository()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/StaticAdd.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/StaticAdd.xaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/StaticFile.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/StaticFile.xaml.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/StaticFolder.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/StaticFolder.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class StaticFolder : UserControl
-    {
-        public StaticFolder()
-        {
-            this.InitializeComponent();
-        }
+	public class StaticFolder : UserControl
+	{
+		public StaticFolder()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class TestMergeManager : UserControl
-    {
-        public TestMergeManager()
-        {
-            this.InitializeComponent();
-        }
+	public class TestMergeManager : UserControl
+	{
+		public TestMergeManager()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/UserManager.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/UserManager.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class UserManager : UserControl
-    {
-        public UserManager()
-        {
-            this.InitializeComponent();
-        }
+	public class UserManager : UserControl
+	{
+		public UserManager()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Watchdog.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Watchdog.xaml.cs
@@ -1,19 +1,18 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
 namespace Tgstation.Server.ControlPanel.Views.Pages
 {
-    public class Watchdog : UserControl
-    {
-        public Watchdog()
-        {
-            this.InitializeComponent();
-        }
+	public class Watchdog : UserControl
+	{
+		public Watchdog()
+		{
+			this.InitializeComponent();
+		}
 
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
-    }
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
 }

--- a/src/Tgstation.Server.ControlPanel/Views/ServerBrowser.xaml.cs
+++ b/src/Tgstation.Server.ControlPanel/Views/ServerBrowser.xaml.cs
@@ -1,12 +1,10 @@
 ﻿using Avalonia.Controls;
-using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
-using Tgstation.Server.ControlPanel.ViewModels;
 
 namespace Tgstation.Server.ControlPanel.Views
 {
-    public class ServerBrowser : UserControl
-    {
-        public ServerBrowser() => AvaloniaXamlLoader.Load(this);
+	public class ServerBrowser : UserControl
+	{
+		public ServerBrowser() => AvaloniaXamlLoader.Load(this);
 	}
 }


### PR DESCRIPTION
Added a default EditorConfig for .NET and modified the rules to use tabs for preferred indentation (as requested by Cyberboss).

Through suggestions, manually applied...
- Name simplification on solution (byebye ``String``!)
- Move switch blocks to switch expressions where appropriate
- Remove unnecessary suppression of errors that no longer are raised
- Simplify substrings with new string indexing
- Pass cancellationToken when available from calling method

After this, used code cleanup to enforce indentation as tabs as well as the following rules...
- Format document
- Sort usings
- Remove unnecessary usings
- Remove unnecessary casts
- Apply file header preferences
- Sort accessibility modifiers
- Make private fields readonly when possible
- Apply language/framework type preferences

This PR relies on changes from #68, and should be merged after.