### PR TITLE
Remove reliance on IsVisible for paging views, performance gains, fix avalonia previews

### DIFF
--- a/src/Tgstation.Server.ControlPanel/Models/Credentials.cs
+++ b/src/Tgstation.Server.ControlPanel/Models/Credentials.cs
@@ -29,7 +29,7 @@ namespace Tgstation.Server.ControlPanel.Models
 
 		byte[] cipherText;
 
-		
+
 		void Encrypt(string cleartext)
 		{
 			if (cleartext == null)

--- a/src/Tgstation.Server.ControlPanel/Program.cs
+++ b/src/Tgstation.Server.ControlPanel/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Avalonia;
 using Avalonia.ReactiveUI;
 
@@ -6,12 +6,21 @@ namespace Tgstation.Server.ControlPanel
 {
 	static class Program
 	{
-		public static void Main(string[] args) => BuildAvaloniaApp(args).StartWithClassicDesktopLifetime(args);
+		/// <summary>
+		/// Used for passing through to BuildAvaloniaApp, needed for the Win32-HACK's compatability with the Avalonia in-editor viewer
+		/// </summary>
+		private static string[] ApplicationArgs;
 
-		public static AppBuilder BuildAvaloniaApp(string[] args)
+		public static void Main(string[] args) 
+		{
+			ApplicationArgs = args;
+			BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+		} 
+
+		public static AppBuilder BuildAvaloniaApp()
 		{
 			AppBuilder app = AppBuilder.Configure<App>();
-			if (args.FirstOrDefault()?.ToUpperInvariant() == "--WIN32-HACK")
+			if (ApplicationArgs?.FirstOrDefault()?.ToUpperInvariant() == "--WIN32-HACK")
 				app
 					.UseWin32()
 					.UseReactiveUI()

--- a/src/Tgstation.Server.ControlPanel/Program.cs
+++ b/src/Tgstation.Server.ControlPanel/Program.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Avalonia;
 using Avalonia.ReactiveUI;
 
@@ -11,11 +11,11 @@ namespace Tgstation.Server.ControlPanel
 		/// </summary>
 		private static string[] ApplicationArgs;
 
-		public static void Main(string[] args) 
+		public static void Main(string[] args)
 		{
 			ApplicationArgs = args;
 			BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
-		} 
+		}
 
 		public static AppBuilder BuildAvaloniaApp()
 		{

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
@@ -230,6 +230,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		UserViewModel userVM;
 
+		public string GitHubToken { get; set; }
+
 		bool usingHttp;
 		bool confirmingDelete;
 		bool usingDefaultCredentials;

--- a/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/ConnectionManagerViewModel.cs
@@ -230,14 +230,21 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 
 		UserViewModel userVM;
 
-		public string GitHubToken { get; set; }
+		public string GitHubToken
+		{
+			get => getGitHubToken();
+			set => setGitHubToken(value);
+		}
 
 		bool usingHttp;
 		bool confirmingDelete;
 		bool usingDefaultCredentials;
 		bool isExpanded;
 
-		public ConnectionManagerViewModel(IServerClientFactory serverClientFactory, IRequestLogger requestLogger, Connection connection, PageContextViewModel pageContext, Action onDelete, IJobSink jobSink, Octokit.IGitHubClient gitHubClient)
+		Action<string> setGitHubToken { get; }
+		Func<string> getGitHubToken { get; }
+
+		public ConnectionManagerViewModel(IServerClientFactory serverClientFactory, IRequestLogger requestLogger, Connection connection, PageContextViewModel pageContext, Action onDelete, IJobSink jobSink, Octokit.IGitHubClient gitHubClient, Action<string> setGitHubToken, Func<string> getGitHubToken)
 		{
 			this.serverClientFactory = serverClientFactory ?? throw new ArgumentNullException(nameof(serverClientFactory));
 			this.connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -246,6 +253,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			this.pageContext = pageContext ?? throw new ArgumentNullException(nameof(pageContext));
 			this.jobSink = jobSink?.GetServerSink(() => serverClient, () => connection.JobRequeryRate, () => Title, () => userVM?.User) ?? throw new ArgumentNullException(nameof(jobSink));
 			this.gitHubClient = gitHubClient ?? throw new ArgumentNullException(nameof(gitHubClient));
+			this.setGitHubToken = setGitHubToken ?? throw new ArgumentNullException(nameof(setGitHubToken));
+			this.getGitHubToken = getGitHubToken ?? throw new ArgumentNullException(nameof(getGitHubToken));
 
 			Connect = new EnumCommand<ConnectionManagerCommand>(ConnectionManagerCommand.Connect, this);
 			Close = new EnumCommand<ConnectionManagerCommand>(ConnectionManagerCommand.Close, this);

--- a/src/Tgstation.Server.ControlPanel/ViewModels/MainWindowViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/MainWindowViewModel.cs
@@ -198,7 +198,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			{
 				settings.Connections.Remove(connection);
 				Connections = new List<ConnectionManagerViewModel>(Connections.Where(x => x != newManager));
-			}, Jobs, gitHubClient);
+			}, Jobs, gitHubClient, (x) => GitHubToken = x, () => GitHubToken);
 			return newManager;
 		}
 

--- a/src/Tgstation.Server.ControlPanel/Views/MainView.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/MainView.xaml
@@ -5,6 +5,66 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Tgstation.Server.ControlPanel.Views.MainView">
 
+  <UserControl.DataTemplates>
+    <DataTemplate DataType="{x:Type vms:ConnectionManagerViewModel}">
+      <page:AddServer />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:AddUserViewModel}">
+      <page:AddUser />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:AdministrationViewModel}">
+      <page:Administration />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:UserViewModel}">
+      <page:UserManager />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:AddInstanceViewModel}">
+      <page:AddInstance />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:InstanceViewModel}">
+      <page:InstanceManager />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:AddInstanceUserViewModel}">
+      <page:AddInstanceUser />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:InstanceUserViewModel}">
+      <page:InstanceUser />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:RepositoryViewModel}">
+      <page:Repository />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:StaticFolderViewModel}">
+      <page:StaticFolder />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:StaticFileViewModel}">
+      <page:StaticFile />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:AddGroupViewModel}">
+      <page:AddUserGroup />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:UserGroupViewModel}">
+      <page:GroupManager />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:AddStaticItemViewModel}">
+      <page:StaticAdd />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:DreamDaemonViewModel}">
+      <page:Watchdog />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:AddChatBotViewModel}">
+      <page:AddChatBot />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:ChatBotViewModel}">
+      <page:ChatBot />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:CompilerViewModel}">
+      <page:DreamMaker />
+    </DataTemplate>
+    <DataTemplate DataType="{x:Type vms:ByondViewModel}">
+      <page:Byond />
+    </DataTemplate>
+  </UserControl.DataTemplates>
+  
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="*"/>
@@ -38,25 +98,7 @@
           <RowDefinition Height="1*"/>
         </Grid.RowDefinitions>
         <Panel Grid.Row="0" >
-          <page:AddServer IsVisible="{Binding PageContext.IsConnectionManager}" IsEnabled="{Binding PageContext.IsConnectionManager}"/>
-          <page:AddUser IsVisible="{Binding PageContext.IsAddUser}" IsEnabled="{Binding PageContext.IsAddUser}"/>
-          <page:Administration IsVisible="{Binding PageContext.IsAdministration}" IsEnabled="{Binding PageContext.IsAdministration}"/>
-          <page:UserManager IsVisible="{Binding PageContext.IsUser}" IsEnabled="{Binding PageContext.IsUser}"/>
-          <page:AddInstance IsVisible="{Binding PageContext.IsAddInstance}" IsEnabled="{Binding PageContext.IsAddInstance}"/>
-          <page:InstanceManager IsVisible="{Binding PageContext.IsInstance}" IsEnabled="{Binding PageContext.IsInstance}"/>
-          <page:AddInstanceUser IsVisible="{Binding PageContext.IsAddInstanceUser}" IsEnabled="{Binding PageContext.IsAddInstanceUser}"/>
-          <page:InstanceUser IsVisible="{Binding PageContext.IsInstanceUser}" IsEnabled="{Binding PageContext.IsInstanceUser}"/>
-          <page:Repository IsVisible="{Binding PageContext.IsRepository}" IsEnabled="{Binding PageContext.IsRepository}"/>
-          <page:StaticFolder IsVisible="{Binding PageContext.IsStaticFolder}" IsEnabled="{Binding PageContext.IsStaticFolder}"/>
-          <page:StaticFile IsVisible="{Binding PageContext.IsStaticFile}" IsEnabled="{Binding PageContext.IsStaticFile}"/>
-          <page:AddUserGroup IsVisible="{Binding PageContext.IsAddGroup}" IsEnabled="{Binding PageContext.IsAddGroup}"/>
-          <page:GroupManager IsVisible="{Binding PageContext.IsGroup}" IsEnabled="{Binding PageContext.IsGroup}"/>
-          <page:StaticAdd IsVisible="{Binding PageContext.IsStaticAdd}" IsEnabled="{Binding PageContext.IsStaticAdd}"/>
-          <page:Watchdog IsVisible="{Binding PageContext.IsDreamDaemon}" IsEnabled="{Binding PageContext.IsDreamDaemon}"/>
-          <page:AddChatBot IsVisible="{Binding PageContext.IsAddChatBot}" IsEnabled="{Binding PageContext.IsAddChatBot}"/>
-          <page:ChatBot IsVisible="{Binding PageContext.IsChatBot}" IsEnabled="{Binding PageContext.IsChatBot}"/>
-          <page:DreamMaker IsVisible="{Binding PageContext.IsCompiler}" IsEnabled="{Binding PageContext.IsCompiler}"/>
-          <page:Byond IsVisible="{Binding PageContext.IsByond}" IsEnabled="{Binding PageContext.IsByond}"/>
+          <ContentControl Content="{Binding PageContext.ActiveObject}" />
         </Panel>
         <GridSplitter HorizontalAlignment="Right"
                       VerticalAlignment="Stretch"

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddChatBot.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddChatBot.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -30,18 +30,18 @@
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="Name:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.BotName, Mode=TwoWay}"/>
+          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding BotName, Mode=TwoWay}"/>
           <TextBlock Text="Provider:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
 
-          <ComboBox SelectedIndex="{Binding PageContext.ActiveObject.Provider, Mode=TwoWay}" Grid.Column="1" Grid.Row="1" Margin="50,0,0,5">
+          <ComboBox SelectedIndex="{Binding Provider, Mode=TwoWay}" Grid.Column="1" Grid.Row="1" Margin="50,0,0,5">
             <ComboBoxItem>Internet Relay Chat</ComboBoxItem>
             <ComboBoxItem>Discord</ComboBoxItem>
           </ComboBox>
         </Grid>
-        <CheckBox Content="Enabled" IsChecked="{Binding PageContext.ActiveObject.Enabled}"/>
+        <CheckBox Content="Enabled" IsChecked="{Binding Enabled}"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-        <Grid IsVisible="{Binding PageContext.ActiveObject.IrcSelected}">
+        <Grid IsVisible="{Binding IrcSelected}">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
@@ -57,23 +57,23 @@
             <RowDefinition Height="Auto" />
           </Grid.RowDefinitions>
           <TextBlock Text="Server Address:" Grid.Column="0" Grid.Row="0" Margin="0,5,0,0"/>
-          <TextBox Text="{Binding PageContext.ActiveObject.IrcServer}" Grid.Column="1" Grid.Row="0" Margin="5,0,0,0"/>
+          <TextBox Text="{Binding IrcServer}" Grid.Column="1" Grid.Row="0" Margin="5,0,0,0"/>
           <TextBlock Text="Server Port:" Grid.Column="0" Grid.Row="1" Margin="0,5,0,0" />
-          <NumericUpDown Minimum="1" Maximum="65535" Value="{Binding PageContext.ActiveObject.IrcPort}" Grid.Column="1" Grid.Row="1" Margin="5,0,0,0"/>
+          <NumericUpDown Minimum="1" Maximum="65535" Value="{Binding IrcPort}" Grid.Column="1" Grid.Row="1" Margin="5,0,0,0"/>
           <TextBlock Text="Nickname:" Grid.Column="0" Grid.Row="2" Margin="0,5,0,0"/>
-          <TextBox Text="{Binding PageContext.ActiveObject.IrcNick}" Grid.Column="1" Grid.Row="2" Margin="5,0,0,0"/>
-          <CheckBox Content="Use SSL" Grid.ColumnSpan="2" Grid.Column="0" Grid.Row="4" IsChecked="{Binding PageContext.ActiveObject.IrcUseSsl}" />
+          <TextBox Text="{Binding IrcNick}" Grid.Column="1" Grid.Row="2" Margin="5,0,0,0"/>
+          <CheckBox Content="Use SSL" Grid.ColumnSpan="2" Grid.Column="0" Grid.Row="4" IsChecked="{Binding IrcUseSsl}" />
           <TextBlock Text="Password Type:" Grid.Column="0" Grid.Row="6" Margin="0,5,0,0"/>
-          <ComboBox SelectedIndex="{Binding PageContext.ActiveObject.IrcPasswordType, Mode=TwoWay}" Grid.Column="1" Grid.Row="6" Margin="5,0,0,0">
+          <ComboBox SelectedIndex="{Binding IrcPasswordType, Mode=TwoWay}" Grid.Column="1" Grid.Row="6" Margin="5,0,0,0">
             <ComboBoxItem>Server Authentication</ComboBoxItem>
             <ComboBoxItem>SASL Authentication</ComboBoxItem>
             <ComboBoxItem>NickServ Authentication</ComboBoxItem>
             <ComboBoxItem>No Password</ComboBoxItem>
           </ComboBox>
           <TextBlock Text="Password:" Grid.Column="0" Grid.Row="7" Margin="0,5,0,0"/>
-          <TextBox Text="{Binding PageContext.ActiveObject.IrcPassword}" IsEnabled="{Binding PageContext.ActiveObject.IrcUsingPassword}" Grid.Column="1" Grid.Row="7"/>
+          <TextBox Text="{Binding IrcPassword}" IsEnabled="{Binding IrcUsingPassword}" Grid.Column="1" Grid.Row="7"/>
         </Grid>
-        <Grid IsVisible="{Binding PageContext.ActiveObject.DiscordSelected}">
+        <Grid IsVisible="{Binding DiscordSelected}">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
@@ -83,17 +83,17 @@
             <RowDefinition Height="Auto"/>
           </Grid.RowDefinitions>
           <TextBlock Text="Bot Token:" Grid.Row="0" Grid.Column="0" Margin="0,5,0,0"/>
-          <TextBox Text="{Binding PageContext.ActiveObject.DiscordBotToken}" Grid.Row="0" Grid.Column="1" Margin="5,0,0,0"/>
-          <ComboBox SelectedIndex="{Binding PageContext.ActiveObject.DiscordDMDisplay, Mode=TwoWay}" Grid.Column="0" Grid.Row="1" Margin="5,0,0,0">
+          <TextBox Text="{Binding DiscordBotToken}" Grid.Row="0" Grid.Column="1" Margin="5,0,0,0"/>
+          <ComboBox SelectedIndex="{Binding DiscordDMDisplay, Mode=TwoWay}" Grid.Column="0" Grid.Row="1" Margin="5,0,0,0">
             <ComboBoxItem>Always Show DM Output</ComboBoxItem>
             <ComboBoxItem>Show DM Output on Error</ComboBoxItem>
             <ComboBoxItem>Never Show DM Output</ComboBoxItem>
           </ComboBox>
-          <CheckBox Content="Based on the Hardware that's Installed in it" Grid.ColumnSpan="2" Grid.Column="1" Grid.Row="1" IsChecked="{Binding PageContext.ActiveObject.DiscordMeme}" />
+          <CheckBox Content="Based on the Hardware that's Installed in it" Grid.ColumnSpan="2" Grid.Column="1" Grid.Row="1" IsChecked="{Binding DiscordMeme}" />
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-        <Button Content="Add Chat Bot" Command="{Binding PageContext.ActiveObject.Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+        <Button Content="Add Chat Bot" Command="{Binding Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddInstance.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddInstance.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -30,15 +30,15 @@
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="Name:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.Name, Mode=TwoWay}"/>
+          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding Name, Mode=TwoWay}"/>
           <TextBlock Text="Instances may be placed in the following paths:" Margin="0,5,0,5" Grid.Column="0" Grid.Row="1" />
-          <TextBlock Text="{Binding PageContext.ActiveObject.ValidPaths}" Margin="50,5,0,5" Grid.Column="1" Grid.Row="1" />
+          <TextBlock Text="{Binding ValidPaths}" Margin="50,5,0,5" Grid.Column="1" Grid.Row="1" />
           <TextBlock Text="Path on Host:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="2" />
-          <TextBox Grid.Column="1" Grid.Row="2" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.Path, Mode=TwoWay}"/>
+          <TextBox Grid.Column="1" Grid.Row="2" Margin="50,0,0,5" Text="{Binding Path, Mode=TwoWay}"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-        <Button Content="Add Instance" Command="{Binding PageContext.ActiveObject.Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+        <Button Content="Add Instance" Command="{Binding Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddInstanceUser.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddInstanceUser.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -28,14 +28,14 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
-          <TextBlock Text="Permission Set Id:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0" IsVisible="{Binding PageContext.ActiveObject.IdMode}"/>
-          <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="50,0,0,0" Minimum="0" IsVisible="{Binding PageContext.ActiveObject.IdMode}" Text="{Binding PageContext.ActiveObject.UserId, Mode=TwoWay}"/>
-          <TextBlock Text="User:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0" IsVisible="{Binding !PageContext.ActiveObject.IdMode}"/>          
-          <ComboBox Items="{Binding PageContext.ActiveObject.UserStrings}" SelectedIndex="{Binding PageContext.ActiveObject.SelectedIndex}" Margin="50,0,0,0" IsVisible="{Binding !PageContext.ActiveObject.IdMode}" Grid.Column="1" Grid.Row="0"/>
+          <TextBlock Text="Permission Set Id:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0" IsVisible="{Binding IdMode}"/>
+          <NumericUpDown Grid.Column="1" Grid.Row="0" Margin="50,0,0,0" Minimum="0" IsVisible="{Binding IdMode}" Text="{Binding UserId, Mode=TwoWay}"/>
+          <TextBlock Text="User:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0" IsVisible="{Binding !IdMode}"/>          
+          <ComboBox Items="{Binding UserStrings}" SelectedIndex="{Binding SelectedIndex}" Margin="50,0,0,0" IsVisible="{Binding !IdMode}" Grid.Column="1" Grid.Row="0"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-        <Button Content="Add User/Group" Command="{Binding PageContext.ActiveObject.Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+        <Button Content="Add User/Group" Command="{Binding Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddServer.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddServer.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -28,7 +28,7 @@
             </LinearGradientBrush>
           </Rectangle.Fill>
         </Rectangle>
-        <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" IsEnabled="{Binding !PageContext.ActiveObject.Connecting}">
+        <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" IsEnabled="{Binding !Connecting}">
           <Grid> 
             <Grid.RowDefinitions>
               <RowDefinition Height="Auto"/>
@@ -41,11 +41,11 @@
               <ColumnDefinition Width="400"/>
             </Grid.ColumnDefinitions>
             <TextBlock Text="Server Address:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.ServerAddress, Mode=TwoWay}" />
+            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding ServerAddress, Mode=TwoWay}" />
             <TextBlock Text="Username:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1"/>
-            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" IsEnabled="{Binding !PageContext.ActiveObject.UsingDefaultCredentials, Mode=OneWay}" Text="{Binding PageContext.ActiveObject.Username, Mode=TwoWay}"/>
+            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" IsEnabled="{Binding !UsingDefaultCredentials, Mode=OneWay}" Text="{Binding Username, Mode=TwoWay}"/>
             <TextBlock Text="Password:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="2" />
-            <TextBox PasswordChar="*" Grid.Column="1" Grid.Row="2" Margin="50,0,0,5" IsEnabled="{Binding !PageContext.ActiveObject.UsingDefaultCredentials}" Text="{Binding PageContext.ActiveObject.Password, Mode=TwoWay}"/>
+            <TextBox PasswordChar="*" Grid.Column="1" Grid.Row="2" Margin="50,0,0,5" IsEnabled="{Binding !UsingDefaultCredentials}" Text="{Binding Password, Mode=TwoWay}"/>
             <TextBlock Text="GitHub Token (global, optional):" Margin="0,5,0,0" Grid.Column="0" Grid.Row="4" />
             <TextBox PasswordChar="*" Grid.Column="1" Grid.Row="4" Margin="50,0,0,5" Text="{Binding GitHubToken, Mode=TwoWay}"/>
           </Grid>
@@ -62,11 +62,11 @@
             </Grid.ColumnDefinitions>
             <DockPanel Grid.Column="1">
               <TextBlock DockPanel.Dock="Left" Text="Connection Timeout (ms):" Margin="0,4,5,0" />
-              <NumericUpDown DockPanel.Dock="Right" Minimum="0" Value="{Binding PageContext.ActiveObject.TimeoutMs, Mode=TwoWay}"/>
+              <NumericUpDown DockPanel.Dock="Right" Minimum="0" Value="{Binding TimeoutMs, Mode=TwoWay}"/>
             </DockPanel>
             <DockPanel Grid.Column="3">
               <TextBlock DockPanel.Dock="Left" Text="Job Refresh Rate (ms):" Margin="0,4,5,0" />
-              <NumericUpDown DockPanel.Dock="Right" Minimum="0" Value="{Binding PageContext.ActiveObject.RequeryMs, Mode=TwoWay}"/>
+              <NumericUpDown DockPanel.Dock="Right" Minimum="0" Value="{Binding RequeryMs, Mode=TwoWay}"/>
             </DockPanel>
           </Grid>
 
@@ -81,15 +81,15 @@
               <ColumnDefinition Width="10*"/>
             </Grid.ColumnDefinitions>
             <DockPanel Grid.Column="1">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.UsingHttp, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding UsingHttp, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Use Plain HTTP" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="3">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.UsingDefaultCredentials, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding UsingDefaultCredentials, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Default Credentials" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="5">
-              <CheckBox DockPanel.Dock="Left" Background="White" IsChecked="{Binding PageContext.ActiveObject.AllowSavingPassword, Mode=TwoWay}"/>
+              <CheckBox DockPanel.Dock="Left" Background="White" IsChecked="{Binding AllowSavingPassword, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Save Password" Margin="5,5,0,0" />
             </DockPanel>
           </Grid>
@@ -103,13 +103,13 @@
               <ColumnDefinition Width="25*"/>
               <ColumnDefinition Width="10*"/>
             </Grid.ColumnDefinitions>
-            <Button Content="{Binding PageContext.ActiveObject.ConnectionWord}" Grid.Column="1" Background="#CFD6E5" BorderBrush="#ADADAD" Command="{Binding PageContext.ActiveObject.Connect}"/>
-            <Button Content="{Binding PageContext.ActiveObject.DeleteWord}" Grid.Column="3" Background="#CFD6E5" BorderBrush="#ADADAD" Command="{Binding PageContext.ActiveObject.Delete}"/> 
+            <Button Content="{Binding ConnectionWord}" Grid.Column="1" Background="#CFD6E5" BorderBrush="#ADADAD" Command="{Binding Connect}"/>
+            <Button Content="{Binding DeleteWord}" Grid.Column="3" Background="#CFD6E5" BorderBrush="#ADADAD" Command="{Binding Delete}"/> 
           </Grid>
-          <StackPanel Orientation="Vertical" IsVisible="{Binding PageContext.ActiveObject.Errored}" >
+          <StackPanel Orientation="Vertical" IsVisible="{Binding Errored}" >
             <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
             <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-            <TextBlock Text="{Binding PageContext.ActiveObject.ErrorMessage}" HorizontalAlignment="Center" FontSize="18"/>
+            <TextBlock Text="{Binding ErrorMessage}" HorizontalAlignment="Center" FontSize="18"/>
           </StackPanel>
         </StackPanel>
       </StackPanel>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddUser.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddUser.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -30,11 +30,11 @@
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="Username:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.Username, Mode=TwoWay}"/>
+          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding Username, Mode=TwoWay}"/>
           <TextBlock Text="Password:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
-          <TextBox PasswordChar="*" Watermark="{Binding PageContext.ActiveObject.PasswordLength}" Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.Password, Mode=TwoWay}"/>
+          <TextBox PasswordChar="*" Watermark="{Binding PasswordLength}" Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding Password, Mode=TwoWay}"/>
           <TextBlock Text="Confirm Password:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="2" />
-          <TextBox PasswordChar="*" Watermark="{Binding PageContext.ActiveObject.PasswordLength}" Grid.Column="1" Grid.Row="2" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.ConfirmPassword, Mode=TwoWay}"/>
+          <TextBox PasswordChar="*" Watermark="{Binding PasswordLength}" Grid.Column="1" Grid.Row="2" Margin="50,0,0,5" Text="{Binding ConfirmPassword, Mode=TwoWay}"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -53,11 +53,11 @@
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="System Username:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBox Grid.Column="1" Grid.Row="0" Margin="8,0,42,5" Text="{Binding PageContext.ActiveObject.SystemIdentifier, Mode=TwoWay}"/>
+          <TextBox Grid.Column="1" Grid.Row="0" Margin="8,0,42,5" Text="{Binding SystemIdentifier, Mode=TwoWay}"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-        <Button Content="Add User" Command="{Binding PageContext.ActiveObject.Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+        <Button Content="Add User" Command="{Binding Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/AddUserGroup.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/AddUserGroup.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -28,9 +28,9 @@
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="Group Name:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.GroupName, Mode=TwoWay}"/>
+          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding GroupName, Mode=TwoWay}"/>
         </Grid>
-        <Button Content="Add Group" Command="{Binding PageContext.ActiveObject.Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+        <Button Content="Add Group" Command="{Binding Add}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Administration.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Administration.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -24,10 +24,10 @@
             <ColumnDefinition Width="100"/>
           </Grid.ColumnDefinitions>
           <TextBlock Grid.Column="0" Text="Server Administration" FontSize="26"/>
-          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Refreshing}" Margin="0,0,5,0"/>
-          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.error.png" IsVisible="{Binding PageContext.ActiveObject.Error}" Margin="0,0,5,0"/>
-          <TextBlock Grid.Column="2" Text="{Binding PageContext.ActiveObject.ErrorMessage}" IsVisible="{Binding PageContext.ActiveObject.Error}" Margin="0,10,0,0"/>
-          <Button Grid.Column="3" Content="Refresh" Command="{Binding PageContext.ActiveObject.RefreshCmd}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Refreshing}" Margin="0,0,5,0"/>
+          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.error.png" IsVisible="{Binding Error}" Margin="0,0,5,0"/>
+          <TextBlock Grid.Column="2" Text="{Binding ErrorMessage}" IsVisible="{Binding Error}" Margin="0,10,0,0"/>
+          <Button Grid.Column="3" Content="Refresh" Command="{Binding RefreshCmd}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -45,13 +45,13 @@
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="Windows Host Machine:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.WindowsHostMachine}" Margin="50,0,0,5" Grid.Column="1" Grid.Row="0" />
+          <TextBlock Text="{Binding WindowsHostMachine}" Margin="50,0,0,5" Grid.Column="1" Grid.Row="0" />
           <TextBlock Text="Updates GitHub Repository:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="2" />
-          <Button Grid.Column="1" Grid.Row="2" Margin="50,0,0,5" Content="{Binding PageContext.ActiveObject.GitHubUrl}" Command="{Binding PageContext.ActiveObject.OpenGitHub}" Background="#CFD6E5" Foreground="#31A2EC"  BorderBrush="#CFD6E5"/>
+          <Button Grid.Column="1" Grid.Row="2" Margin="50,0,0,5" Content="{Binding GitHubUrl}" Command="{Binding OpenGitHub}" Background="#CFD6E5" Foreground="#31A2EC"  BorderBrush="#CFD6E5"/>
           <TextBlock Text="Latest Available Version:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="4"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.LatestVersionString}" Margin="0,5,0,0" Grid.Column="1" Grid.Row="4"/>
+          <TextBlock Text="{Binding LatestVersionString}" Margin="0,5,0,0" Grid.Column="1" Grid.Row="4"/>
           <TextBlock Text="Update To Version:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="5" />
-          <TextBox Grid.Column="1" Grid.Row="5" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.NewVersion, Mode=TwoWay}"/>
+          <TextBox Grid.Column="1" Grid.Row="5" Margin="50,0,0,5" Text="{Binding NewVersion, Mode=TwoWay}"/>
         </Grid>
       <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
       <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -69,13 +69,13 @@
             <ColumnDefinition Width="15*"/>
             <ColumnDefinition Width="25*"/>
           </Grid.ColumnDefinitions>
-          <Button Grid.Column="1" Content="{Binding PageContext.ActiveObject.UpdateText}" Command="{Binding PageContext.ActiveObject.Update}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
-          <Button Grid.Column="3" Content="{Binding PageContext.ActiveObject.RestartText}" Command="{Binding PageContext.ActiveObject.Restart}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Button Grid.Column="1" Content="{Binding UpdateText}" Command="{Binding Update}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Button Grid.Column="3" Content="{Binding RestartText}" Command="{Binding Restart}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
       </Grid>
-      <StackPanel IsVisible="{Binding PageContext.ActiveObject.CanGetLogs}">
+      <StackPanel IsVisible="{Binding CanGetLogs}">
         <TextBlock Text="Log Downloads" Margin="3" FontSize="20" Grid.Column="0"/>
-        <ItemsControl Items="{Binding PageContext.ActiveObject.LogFiles}">
+        <ItemsControl Items="{Binding LogFiles}">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
               <Button Content="{Binding DisplayText}" Command="{Binding Download}"/>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Byond.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Byond.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -24,20 +24,20 @@
             <ColumnDefinition Width="150"/>
           </Grid.ColumnDefinitions>
           <TextBlock Grid.Column="0" Text="Byond" FontSize="26" />
-          <Image Grid.Column="2" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Refreshing}" Margin="0,0,5,0"/>
-          <Button Grid.Column="3" Content="Refresh" Command="{Binding PageContext.ActiveObject.Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Image Grid.Column="2" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Refreshing}" Margin="0,0,5,0"/>
+          <Button Grid.Column="3" Content="Refresh" Command="{Binding Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Active Version:"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.CurrentVersion}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding CurrentVersion}" Margin="5,0,0,0"/>
         </StackPanel>
-        <StackPanel IsVisible="{Binding PageContext.ActiveObject.HasInstalledVersions}">
+        <StackPanel IsVisible="{Binding HasInstalledVersions}">
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
           <TextBlock Text="Installed Versions:"/>
-          <ItemsControl Items="{Binding PageContext.ActiveObject.InstalledVersions}">
+          <ItemsControl Items="{Binding InstalledVersions}">
             <ItemsControl.ItemTemplate>
               <DataTemplate>
                 <TextBlock Text="{Binding}"/>
@@ -61,11 +61,11 @@
             <ColumnDefinition Width="100" />
           </Grid.ColumnDefinitions>
           <TextBlock Text="Major:" Grid.Row="0" Grid.Column="0" Margin="0,5,0,0"/>
-          <NumericUpDown Minimum="1" Value="{Binding PageContext.ActiveObject.NewMajor}" Margin="0,0,5,0" Grid.Row="0" Grid.Column="1"/>
+          <NumericUpDown Minimum="1" Value="{Binding NewMajor}" Margin="0,0,5,0" Grid.Row="0" Grid.Column="1"/>
           <TextBlock Text="Minor:" Grid.Row="2" Grid.Column="0" Margin="0,5,0,0"/>
-          <NumericUpDown Minimum="1" Value="{Binding PageContext.ActiveObject.NewMinor}" Margin="0,0,5,0" Grid.Row="2" Grid.Column="1"/>
+          <NumericUpDown Minimum="1" Value="{Binding NewMinor}" Margin="0,0,5,0" Grid.Row="2" Grid.Column="1"/>
           <TextBlock Text="Prebuild:" Grid.Row="5" Grid.Column="0" Margin="0,5,0,0"/>
-          <NumericUpDown Minimum="1" Value="{Binding PageContext.ActiveObject.Prebuild}" Margin="0,0,5,0" Grid.Row="5" Grid.Column="1"/>
+          <NumericUpDown Minimum="1" Value="{Binding Prebuild}" Margin="0,0,5,0" Grid.Row="5" Grid.Column="1"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -82,8 +82,8 @@
             <RowDefinition Height="Auto" />
           </Grid.RowDefinitions>
           <TextBlock Text="Upload From File:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBox Text="{Binding PageContext.ActiveObject.ByondZipPath}" IsEnabled="{Binding PageContext.ActiveObject.CanUpload}" Grid.Column="1" Margin="5,0,0,0" Grid.Row="0"/>
-          <Button Content="..." Command="{Binding PageContext.ActiveObject.Browse}" Grid.Column="2" Grid.Row="0"/>
+          <TextBox Text="{Binding ByondZipPath}" IsEnabled="{Binding CanUpload}" Grid.Column="1" Margin="5,0,0,0" Grid.Row="0"/>
+          <Button Content="..." Command="{Binding Browse}" Grid.Column="2" Grid.Row="0"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -93,7 +93,7 @@
             <ColumnDefinition Width="20*"/>
             <ColumnDefinition Width="40*"/>
           </Grid.ColumnDefinitions>
-          <Button Content="{Binding PageContext.ActiveObject.ApplyText}" Command="{Binding PageContext.ActiveObject.Update}" Grid.Column="1"/>
+          <Button Content="{Binding ApplyText}" Command="{Binding Update}" Grid.Column="1"/>
         </Grid>
       </StackPanel>
     </ScrollViewer>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/ChatBot.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/ChatBot.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -22,32 +22,32 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="100"/>
           </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.Title}" FontSize="26"/>
-          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Refreshing}" Margin="0,0,5,0"/>
-          <Button Grid.Column="2" Content="Refresh" Command="{Binding PageContext.ActiveObject.Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <TextBlock Grid.Column="0" Text="{Binding Title}" FontSize="26"/>
+          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Refreshing}" Margin="0,0,5,0"/>
+          <Button Grid.Column="2" Content="Refresh" Command="{Binding Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
         <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
           <TextBlock Text="Provider:" />
-          <TextBlock Text="{Binding PageContext.ActiveObject.Provider}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding Provider}" Margin="5,0,0,0"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Enabled:" />
-          <TextBlock Text="{Binding PageContext.ActiveObject.Enabled}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding Enabled}" Margin="5,0,0,0"/>
         </StackPanel>
-        <StackPanel IsVisible="{Binding PageContext.ActiveObject.HasConnectionString}" Orientation="Horizontal">
+        <StackPanel IsVisible="{Binding HasConnectionString}" Orientation="Horizontal">
           <TextBlock Text="Connection String:" />
-          <TextBlock Text="{Binding PageContext.ActiveObject.ChatBot.ConnectionString}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding ChatBot.ConnectionString}" Margin="5,0,0,0"/>
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-        <CheckBox IsChecked="{Binding PageContext.ActiveObject.NewEnabled}" IsEnabled="{Binding PageContext.ActiveObject.CanEnable}" Content="Enabled" Background="White" Margin="0,5,0,5" />
+        <CheckBox IsChecked="{Binding NewEnabled}" IsEnabled="{Binding CanEnable}" Content="Enabled" Background="White" Margin="0,5,0,5" />
         <Grid>
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
           <TextBlock Text="New Connection String:" Grid.Column="0" Margin="0,5,0,0"/>
-          <TextBox Text="{Binding PageContext.ActiveObject.NewConnectionString}" IsEnabled="{Binding PageContext.ActiveObject.CanConnectionString}" Margin="5,0,0,0" Grid.Column="1"/>
+          <TextBox Text="{Binding NewConnectionString}" IsEnabled="{Binding CanConnectionString}" Margin="5,0,0,0" Grid.Column="1"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -62,12 +62,12 @@
           </Grid.ColumnDefinitions>
           <TextBlock Text="Channels" FontSize="20" Grid.Column="0"/>
           <TextBlock Text="Maximum:" FontSize="15" Grid.Column="1"/>
-          <NumericUpDown Minimum="1" Maximum="65535" IsEnabled="{Binding PageContext.ActiveObject.CanChannelLimit}" Value="{Binding PageContext.ActiveObject.NewChannelLimit}" Grid.Column="2"/>
-          <Button Grid.Column="4" Content="Add Channel" Command="{Binding PageContext.ActiveObject.AddChannel}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <NumericUpDown Minimum="1" Maximum="65535" IsEnabled="{Binding CanChannelLimit}" Value="{Binding NewChannelLimit}" Grid.Column="2"/>
+          <Button Grid.Column="4" Content="Add Channel" Command="{Binding AddChannel}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-        <ItemsControl Items="{Binding PageContext.ActiveObject.Channels}" Margin="0,5,0,0" IsEnabled="{Binding PageContext.ActiveObject.CanChannels}">
+        <ItemsControl Items="{Binding Channels}" Margin="0,5,0,0" IsEnabled="{Binding CanChannels}">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
               <StackPanel Orientation="Vertical" Margin="5">
@@ -115,8 +115,8 @@
               <ColumnDefinition Width="20*"/>
               <ColumnDefinition Width="10*"/>
             </Grid.ColumnDefinitions>
-            <Button Content="Apply Changes" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Update}" Margin="0,0,5,0" />
-            <Button Content="{Binding PageContext.ActiveObject.DeleteText}" Grid.Column="3" Command="{Binding PageContext.ActiveObject.Delete}" Margin="0,0,5,0" />
+            <Button Content="Apply Changes" Grid.Column="1" Command="{Binding Update}" Margin="0,0,5,0" />
+            <Button Content="{Binding DeleteText}" Grid.Column="3" Command="{Binding Delete}" Margin="0,0,5,0" />
           </Grid>
       </StackPanel>
     </ScrollViewer>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/DreamMaker.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/DreamMaker.xaml
@@ -12,8 +12,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -25,15 +25,15 @@
             <ColumnDefinition Width="100"/>
           </Grid.ColumnDefinitions>
           <TextBlock Grid.Column="0" Text="Deployment" FontSize="26" />
-          <Image Grid.Column="2" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Refreshing}" Margin="0,0,5,0"/>
-          <Button Grid.Column="3" Content="Refresh" Command="{Binding PageContext.ActiveObject.Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Image Grid.Column="2" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Refreshing}" Margin="0,0,5,0"/>
+          <Button Grid.Column="3" Content="Refresh" Command="{Binding Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
-        <StackPanel IsVisible="{Binding PageContext.ActiveObject.HasInstalledVersions}">
+        <StackPanel IsVisible="{Binding HasInstalledVersions}">
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
           <TextBlock Text="Previous Deployments:"/>
-          <local:CompileJobList DataContext="{Binding PageContext.ActiveObject.CurrentPage}"/>
-          <Grid IsVisible="{Binding PageContext.ActiveObject.CanRead}">
+          <local:CompileJobList DataContext="{Binding CurrentPage}"/>
+          <Grid IsVisible="{Binding CanRead}">
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="50*"/>
               <ColumnDefinition Width="5*"/>
@@ -41,14 +41,14 @@
               <ColumnDefinition Width="5*"/>
               <ColumnDefinition Width="50*"/>
             </Grid.ColumnDefinitions>
-            <Button Content="&lt;" Command="{Binding PageContext.ActiveObject.LastPage}" Grid.Column="1"/>
+            <Button Content="&lt;" Command="{Binding LastPage}" Grid.Column="1"/>
             <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5,0,0">
               <TextBlock Text="Page:"/>
-              <TextBlock Text="{Binding PageContext.ActiveObject.ViewSelectedPage}" Margin="5,0,0,0"/>
+              <TextBlock Text="{Binding ViewSelectedPage}" Margin="5,0,0,0"/>
               <TextBlock Text=" of "/>
-              <TextBlock Text="{Binding PageContext.ActiveObject.ViewNumPages}"/>
+              <TextBlock Text="{Binding ViewNumPages}"/>
             </StackPanel>
-            <Button Content="&gt;" Command="{Binding PageContext.ActiveObject.NextPage}" Grid.Column="3"/>
+            <Button Content="&gt;" Command="{Binding NextPage}" Grid.Column="3"/>
           </Grid>
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
@@ -66,11 +66,11 @@
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
           <TextBlock Text="Project Name:" Grid.Row="0" Grid.Column="0"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.ProjectName}" Margin="5,0,0,0" Grid.Row="0" Grid.Column="1"/>
+          <TextBlock Text="{Binding ProjectName}" Margin="5,0,0,0" Grid.Row="0" Grid.Column="1"/>
           <TextBlock Text="DMAPI Port:" Grid.Row="2" Grid.Column="0"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.Model.ApiValidationPort}" Margin="5,0,0,0" Grid.Row="2" Grid.Column="1"/>
+          <TextBlock Text="{Binding Model.ApiValidationPort}" Margin="5,0,0,0" Grid.Row="2" Grid.Column="1"/>
           <TextBlock Text="Validation Security Level:" Grid.Row="5" Grid.Column="0"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.SecurityLevel}" Margin="5,0,0,0" Grid.Row="5" Grid.Column="1"/>
+          <TextBlock Text="{Binding SecurityLevel}" Margin="5,0,0,0" Grid.Row="5" Grid.Column="1"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -87,19 +87,19 @@
             <ColumnDefinition Width="400" />
           </Grid.ColumnDefinitions>
           <TextBlock Text="New Project Name (without '.dme'):" Grid.Row="2" Grid.Column="0" Margin="0,5,0,0"/>
-          <TextBox Text="{Binding PageContext.ActiveObject.NewDme}" IsEnabled="{Binding PageContext.ActiveObject.CanDmeView}" Margin="5,0,0,0" Grid.Row="2" Grid.Column="1"/>
+          <TextBox Text="{Binding NewDme}" IsEnabled="{Binding CanDmeView}" Margin="5,0,0,0" Grid.Row="2" Grid.Column="1"/>
           <DockPanel Grid.Row="0" Grid.Column="0">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.AutoDetectDme}" IsEnabled="{Binding PageContext.ActiveObject.CanDmeAutodetectView}" DockPanel.Dock="Left"/>
+            <CheckBox Background="White" IsChecked="{Binding AutoDetectDme}" IsEnabled="{Binding CanDmeAutodetectView}" DockPanel.Dock="Left"/>
             <TextBlock Text="Auto Detect Project Name" Margin="5,0,0,0" DockPanel.Dock="Right"/>
           </DockPanel>
           <DockPanel Grid.Row="0" Grid.Column="1">
-            <CheckBox Background="White" ToolTip.Tip="The DMAPI facilitates communication between DreamDaemon and TGS. It enables features such as heartbeats, custom chat commands/messages, and graceful actions such as changing security levels or enabling and disabling the web client among other things. Without it, the server will need to be manually rebooted from TGS when such changes are made." IsChecked="{Binding PageContext.ActiveObject.ApiRequire}" IsEnabled="{Binding PageContext.ActiveObject.CanRequire}" DockPanel.Dock="Left"/>
+            <CheckBox Background="White" ToolTip.Tip="The DMAPI facilitates communication between DreamDaemon and TGS. It enables features such as heartbeats, custom chat commands/messages, and graceful actions such as changing security levels or enabling and disabling the web client among other things. Without it, the server will need to be manually rebooted from TGS when such changes are made." IsChecked="{Binding ApiRequire}" IsEnabled="{Binding CanRequire}" DockPanel.Dock="Left"/>
             <TextBlock Text="Require DMAPI for deployments to succeed (Reccommended)" ToolTip.Tip="The DMAPI facilitates communication between DreamDaemon and TGS. It enables features such as heartbeats, custom chat commands/messages, and graceful actions such as changing security levels or enabling and disabling the web client among other things. Without it, the server will need to be manually rebooted from TGS when such changes are made." Margin="5,0,0,0" DockPanel.Dock="Right"/>
           </DockPanel>
           <TextBlock Text="Port Used For TGS DMAPI Validation (should be private, 0 doesn't change):" Grid.Row="3" Grid.Column="0" Margin="0,5,0,0"/>
-          <NumericUpDown Minimum="0" Maximum="65535"  Value="{Binding PageContext.ActiveObject.NewPort}" IsEnabled="{Binding PageContext.ActiveObject.CanPortView}" Margin="5,0,0,0" Grid.Row="3" Grid.Column="1"/>
+          <NumericUpDown Minimum="0" Maximum="65535"  Value="{Binding NewPort}" IsEnabled="{Binding CanPortView}" Margin="5,0,0,0" Grid.Row="3" Grid.Column="1"/>
         </Grid>
-        <Grid IsEnabled="{Binding PageContext.ActiveObject.CanSecurityView}">
+        <Grid IsEnabled="{Binding CanSecurityView}">
           <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="5"/>
@@ -115,9 +115,9 @@
             <ColumnDefinition Width="10*"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="API Validation Security Level:" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="7" />
-          <RadioButton GroupName="Trust" Content="Ultrasafe" Grid.Row="2" Grid.Column="1" IsChecked="{Binding PageContext.ActiveObject.Ultrasafe}" />
-          <RadioButton GroupName="Trust" Content="Safe" Grid.Row="2" Grid.Column="3" IsChecked="{Binding PageContext.ActiveObject.Safe}" />
-          <RadioButton GroupName="Trust" Content="Trusted" Grid.Row="2" Grid.Column="5" IsChecked="{Binding PageContext.ActiveObject.Trusted}" />
+          <RadioButton GroupName="Trust" Content="Ultrasafe" Grid.Row="2" Grid.Column="1" IsChecked="{Binding Ultrasafe}" />
+          <RadioButton GroupName="Trust" Content="Safe" Grid.Row="2" Grid.Column="3" IsChecked="{Binding Safe}" />
+          <RadioButton GroupName="Trust" Content="Trusted" Grid.Row="2" Grid.Column="5" IsChecked="{Binding Trusted}" />
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -129,8 +129,8 @@
             <ColumnDefinition Width="20*"/>
             <ColumnDefinition Width="30*"/>
           </Grid.ColumnDefinitions>
-          <Button Content="Save Changes" Command="{Binding PageContext.ActiveObject.Update}" Grid.Column="3"/>
-          <Button Content="Deploy Repository Code To Server" Command="{Binding PageContext.ActiveObject.Compile}" Grid.Column="1"/>
+          <Button Content="Save Changes" Command="{Binding Update}" Grid.Column="3"/>
+          <Button Content="Deploy Repository Code To Server" Command="{Binding Compile}" Grid.Column="1"/>
         </Grid>
       </StackPanel>
     </ScrollViewer>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/GroupManager.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/GroupManager.xaml
@@ -12,8 +12,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical" IsEnabled="{Binding !Loading}">
@@ -23,28 +23,28 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="100"/>
           </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.Group.Name}" FontSize="26"/>
-          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Loading}" Margin="0,0,5,0"/>
-          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.error.png" IsVisible="{Binding PageContext.ActiveObject.HasError}" Margin="0,0,5,0"/>
-          <Button Grid.Column="2" Content="Refresh" Command="{Binding PageContext.ActiveObject.Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <TextBlock Grid.Column="0" Text="{Binding Group.Name}" FontSize="26"/>
+          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Loading}" Margin="0,0,5,0"/>
+          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.error.png" IsVisible="{Binding HasError}" Margin="0,0,5,0"/>
+          <Button Grid.Column="2" Content="Refresh" Command="{Binding Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
         <StackPanel Orientation="Vertical">
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="ID:"/>
-            <TextBlock Text="{Binding PageContext.ActiveObject.Group.Id}" Margin="5,0,0,0"/>
+            <TextBlock Text="{Binding Group.Id}" Margin="5,0,0,0"/>
           </StackPanel>
-          <StackPanel Orientation="Vertical" IsVisible="{Binding PageContext.ActiveObject.CanAdd}">
+          <StackPanel Orientation="Vertical" IsVisible="{Binding CanAdd}">
             <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
             <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
             <StackPanel Orientation="Horizontal">
-              <ComboBox Items="{Binding PageContext.ActiveObject.UserStrings}" SelectedIndex="{Binding PageContext.ActiveObject.SelectedIndex}" />
-              <Button Content="Add User" Command="{Binding PageContext.ActiveObject.AddUser}" Background="#CFD6E5" BorderBrush="#ADADAD" Margin="5,0,0,0"/>
+              <ComboBox Items="{Binding UserStrings}" SelectedIndex="{Binding SelectedIndex}" />
+              <Button Content="Add User" Command="{Binding AddUser}" Background="#CFD6E5" BorderBrush="#ADADAD" Margin="5,0,0,0"/>
             </StackPanel>
           </StackPanel>
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
           <TextBlock Text="Members:" FontSize="16"/>
-          <ItemsControl Items="{Binding PageContext.ActiveObject.Group.Users}">
+          <ItemsControl Items="{Binding Group.Users}">
             <ItemsControl.ItemTemplate>
               <DataTemplate>
                 <StackPanel Orientation="Horizontal">

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/InstanceManager.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/InstanceManager.xaml
@@ -11,24 +11,24 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
-        <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.Title}" FontSize="26"/>
+        <TextBlock Grid.Column="0" Text="{Binding Title}" FontSize="26"/>
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="ID:"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.Instance.Id}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding Instance.Id}" Margin="5,0,0,0"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Path:"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.Instance.Path}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding Instance.Path}" Margin="5,0,0,0"/>
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
         <StackPanel Orientation="Horizontal">
-          <CheckBox Background="White" IsEnabled="{Binding PageContext.ActiveObject.CanOnline}" IsChecked="{Binding PageContext.ActiveObject.Enabled, Mode=TwoWay}"/>
+          <CheckBox Background="White" IsEnabled="{Binding CanOnline}" IsChecked="{Binding Enabled, Mode=TwoWay}"/>
           <TextBlock Text="Online" Margin="5,4,0,0" />
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
@@ -44,11 +44,11 @@
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="New Name:" Margin="5,4,50,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBox Background="White" IsEnabled="{Binding PageContext.ActiveObject.CanRename}" Text="{Binding PageContext.ActiveObject.NewName, Mode=TwoWay}" Grid.Column="1" Grid.Row="0"/>
+          <TextBox Background="White" IsEnabled="{Binding CanRename}" Text="{Binding NewName, Mode=TwoWay}" Grid.Column="1" Grid.Row="0"/>
           <TextBlock Text="New Path:" Margin="5,4,50,0"  Grid.Column="0" Grid.Row="1"/>
-          <TextBox Background="White" IsEnabled="{Binding PageContext.ActiveObject.CanRelocate}" Text="{Binding PageContext.ActiveObject.NewPath, Mode=TwoWay}" Grid.Column="1" Grid.Row="1"/>
+          <TextBox Background="White" IsEnabled="{Binding CanRelocate}" Text="{Binding NewPath, Mode=TwoWay}" Grid.Column="1" Grid.Row="1"/>
           <TextBlock Text="Chat Bot Limit:" Margin="5,4,50,0"  Grid.Column="0" Grid.Row="2"/>
-          <NumericUpDown Minimum="0" Maximum="65535"  IsEnabled="{Binding PageContext.ActiveObject.CanChatBot}" Value="{Binding PageContext.ActiveObject.NewChatBotLimit}" Grid.Row="2" Grid.Column="1"/>
+          <NumericUpDown Minimum="0" Maximum="65535"  IsEnabled="{Binding CanChatBot}" Value="{Binding NewChatBotLimit}" Grid.Row="2" Grid.Column="1"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -63,13 +63,13 @@
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="Static File Mode:" Margin="0,5,50,0" Grid.Column="0" Grid.Row="0"/>
-          <ComboBox SelectedIndex="{Binding PageContext.ActiveObject.ConfigMode, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanConfig}" Grid.Column="1" Grid.Row="0">
+          <ComboBox SelectedIndex="{Binding ConfigMode, Mode=TwoWay}" IsEnabled="{Binding CanConfig}" Grid.Column="1" Grid.Row="0">
             <ComboBoxItem>No File Management</ComboBoxItem>
             <ComboBoxItem>Authorized users can read and write any file</ComboBoxItem>
             <ComboBoxItem>Authorized users read and write using their system identity</ComboBoxItem>
           </ComboBox>
           <TextBlock Text="Automatic Update Interval (Minutes) (0 to disable):" Margin="0,5,50,0" Grid.Column="0" Grid.Row="1" />
-          <NumericUpDown Minimum="0" Value="{Binding PageContext.ActiveObject.AutoUpdateInterval, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanAutoUpdate}" Grid.Column="1" Grid.Row="1"/>
+          <NumericUpDown Minimum="0" Value="{Binding AutoUpdateInterval, Mode=TwoWay}" IsEnabled="{Binding CanAutoUpdate}" Grid.Column="1" Grid.Row="1"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -81,9 +81,9 @@
             <ColumnDefinition Width="5*"/>
             <ColumnDefinition Width="15*"/>
           </Grid.ColumnDefinitions>
-          <Button Grid.Column="0" Content="Save" Command="{Binding PageContext.ActiveObject.Save}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
-          <Button Grid.Column="2" Content="Grant Permissions on This Instance" IsEnabled="{Binding PageContext.ActiveObject.CanGetPerms}" Command="{Binding PageContext.ActiveObject.FixPerms}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
-          <Button Grid.Column="4" Content="{Binding PageContext.ActiveObject.DeleteText}" Command="{Binding PageContext.ActiveObject.Delete}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Button Grid.Column="0" Content="Save" Command="{Binding Save}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Button Grid.Column="2" Content="Grant Permissions on This Instance" IsEnabled="{Binding CanGetPerms}" Command="{Binding FixPerms}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Button Grid.Column="4" Content="{Binding DeleteText}" Command="{Binding Delete}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
       </StackPanel>
     </ScrollViewer>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/InstanceUser.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/InstanceUser.xaml
@@ -11,8 +11,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -22,11 +22,11 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="100"/>
           </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.Name}" FontSize="26"/>
-          <Button Grid.Column="2" Content="Refresh" Command="{Binding PageContext.ActiveObject.RefreshCommand}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <TextBlock Grid.Column="0" Text="{Binding Name}" FontSize="26"/>
+          <Button Grid.Column="2" Content="Refresh" Command="{Binding RefreshCommand}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
         <TextBlock Text="Instance Permission Set Rights:" FontSize="16"/>
-        <StackPanel Orientation="Vertical" IsEnabled="{Binding PageContext.ActiveObject.CanEditRights}>">
+        <StackPanel Orientation="Vertical" IsEnabled="{Binding CanEditRights}>">
           <Grid>
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="1*"/>
@@ -37,15 +37,15 @@
               <RowDefinition Height="1*"/>
             </Grid.RowDefinitions>
             <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.UserRead, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding UserRead, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Read Instance Permission Sets" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.UserWrite, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding UserWrite, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Edit Instance Permission Sets" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.UserCreate, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding UserCreate, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Create Instance Permission Sets" Margin="5,4,0,0" />
             </DockPanel>
           </Grid>
@@ -67,55 +67,55 @@
               <RowDefinition Height="1*"/>
             </Grid.RowDefinitions>
             <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoRead, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoRead, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Read Info" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoOrigin, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoOrigin, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Clone Remotes" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoSha, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoSha, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Checkout SHA Hashes" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="1" Grid.Row="1" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoTestMerge, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoTestMerge, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Test Merge" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="0" Grid.Row="2" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoReset, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoReset, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Hard Reset to Origin Branch" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="1" Grid.Row="2" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoCommitter, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoCommitter, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Change Committer Identity" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="0" Grid.Row="3" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoTMCommits, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoTMCommits, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Allow changing the 'Push Test Merge Commits' and 'Post Test Merge Comment' settings" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="1" Grid.Row="3" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoCreds, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoCreds, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Change git Credentials" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="0" Grid.Row="4" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoRef, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoRef, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Checkout Branches and Tags" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="1" Grid.Row="4" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoAuto, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoAuto, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Change Auto Update Settings" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="0" Grid.Row="5" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoDelete, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoDelete, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Delete the Repository" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="1" Grid.Row="5" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoCancelClone, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoCancelClone, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Cancel Clone Jobs" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="0" Grid.Row="6" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.RepoCancelUpdate, Mode=TwoWay}"/>
+              <CheckBox Background="White" IsChecked="{Binding RepoCancelUpdate, Mode=TwoWay}"/>
               <TextBlock DockPanel.Dock="Right" Text="Cancel Update Jobs" Margin="5,4,0,0" />
             </DockPanel>
           </Grid>
@@ -134,23 +134,23 @@
             <RowDefinition Height="1*"/>
           </Grid.RowDefinitions>
           <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ByondRead, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ByondRead, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Read Info" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ByondList, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ByondList, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="List Installed Versions" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ByondChange, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ByondChange, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Install official BYOND releases and switch between installed versions" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ByondCancel, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ByondCancel, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Cancel Install Job" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="2" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ByondUpload, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ByondUpload, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Upload and Install Custom BYOND Versions" Margin="5,4,0,0" />
           </DockPanel>
         </Grid>
@@ -169,35 +169,35 @@
             <RowDefinition Height="1*"/>
           </Grid.RowDefinitions>
           <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.CompRead, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding CompRead, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Read Info" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.CompStart, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding CompStart, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Run Deployments" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.CompCancel, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding CompCancel, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Cancel Deployments" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.CompDme, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding CompDme, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set .dme Name" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="2" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.CompVali, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding CompVali, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set API Validation Port" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="2" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.CompList, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding CompList, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="List and View Compile Jobs" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="3" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.CompSec, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding CompSec, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Change Deployment Security Level" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="3" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.CompReq, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding CompReq, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Change DMAPI Requirement for Deployments" Margin="5,4,0,0" />
           </DockPanel>
         </Grid>
@@ -220,67 +220,67 @@
             <RowDefinition Height="1*"/>
           </Grid.RowDefinitions>
           <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDRead, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDRead, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Read Revision Info" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDPort, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDPort, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set DreamDaemon Port" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDAuto, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDAuto, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set Autostart" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDSec, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDSec, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set Security Level" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="2" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDMeta, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDMeta, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Read Watchdog Info" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="2" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDWeb, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDWeb, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set Web Client" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="3" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDSoftR, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDSoftR, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Gracefully Restart" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="3" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDSoftT, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDSoftT, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Gracefully Shutdown" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="4" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDRes, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDRes, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Hard Restart" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="4" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDTerm, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDTerm, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Hard Shutdown" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="5" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDStart, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDStart, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Start Server" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="5" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDTime, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDTime, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set Startup Timeout Period" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="6" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDHeart, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDHeart, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set Heartbeat Interval" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="6" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDDump, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDDump, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Create Process Dumps" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="7" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDTopicTimeout, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDTopicTimeout, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set Timeout For Sending BYOND Topics" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="7" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DDAdditionalParams, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding DDAdditionalParams, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set Additional DreamDaemon Params" Margin="5,4,0,0" />
           </DockPanel>
         </Grid>
@@ -301,47 +301,47 @@
             <RowDefinition Height="1*"/>
           </Grid.RowDefinitions>
           <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatEnable, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatEnable, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Enable/Disable Bots" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatProvider, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatProvider, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Change Bot Provider" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatChannels, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatChannels, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Change Chat Channels" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatReadString, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatReadString, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Read Connection Details" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="2" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatWriteString, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatWriteString, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Write Connection Details" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="2" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatRead, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatRead, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Read Bot Info" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="3" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatName, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatName, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Change Bot Name" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="3" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatCreate, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatCreate, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Create Bot" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="4" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatDelete, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatDelete, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Delete Bot" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="4" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatChannelLimit, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatChannelLimit, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set Channel Limits" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="5" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.ChatReconnectionInterval, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding ChatReconnectionInterval, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Set Reconnection Interval" Margin="5,4,0,0" />
           </DockPanel>
         </Grid>
@@ -359,19 +359,19 @@
             <RowDefinition Height="1*"/>
           </Grid.RowDefinitions>
           <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.StaticRead, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding StaticRead, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Read Files" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.StaticWrite, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding StaticWrite, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Write Files" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.StaticList, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding StaticList, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="List Files" Margin="5,4,0,0" />
           </DockPanel>
           <DockPanel Grid.Column="1" Grid.Row="1" Margin="2">
-            <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.StaticDelete, Mode=TwoWay}"/>
+            <CheckBox Background="White" IsChecked="{Binding StaticDelete, Mode=TwoWay}"/>
             <TextBlock DockPanel.Dock="Right" Text="Delete Empty Directories" Margin="5,4,0,0" />
           </DockPanel>
         </Grid>
@@ -385,8 +385,8 @@
             <ColumnDefinition Width="15*"/>
             <ColumnDefinition Width="25*"/>
           </Grid.ColumnDefinitions>
-          <Button Grid.Column="1" Content="Save" Command="{Binding PageContext.ActiveObject.Save}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
-          <Button Grid.Column="3" Content="{Binding PageContext.ActiveObject.DeleteText}" Command="{Binding PageContext.ActiveObject.Delete}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Button Grid.Column="1" Content="Save" Command="{Binding Save}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Button Grid.Column="3" Content="{Binding DeleteText}" Command="{Binding Delete}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
       </StackPanel>
     </ScrollViewer>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/PermissionSet.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/PermissionSet.xaml
@@ -5,7 +5,7 @@
     <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
     <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
     <TextBlock Text="Administration Rights:" FontSize="16"/>
-    <Grid IsEnabled="{Binding PageContext.ActiveObject.PermissionSetViewModel.CanEditRights}">
+    <Grid IsEnabled="{Binding PermissionSetViewModel.CanEditRights}">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="1*"/>
         <ColumnDefinition Width="1*"/>
@@ -16,34 +16,34 @@
         <RowDefinition Height="1*"/>
       </Grid.RowDefinitions>
       <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.AdminWriteUsers, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.AdminWriteUsers, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Edit Users" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.AdminEditPassword, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.AdminEditPassword, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Edit Own Password" Margin="5,4,0,0"/>
       </DockPanel>
       <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.AdminRestartServer, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.AdminRestartServer, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Restart Server" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="1" Grid.Row="1" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.AdminChangeVersion, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.AdminChangeVersion, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Change Server Version" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="0" Grid.Row="2" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.AdminReadUsers, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.AdminReadUsers, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Read Users" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="1" Grid.Row="2" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.AdminLogs, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.AdminLogs, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Download Server Logs" Margin="5,4,0,0" />
       </DockPanel>
     </Grid>
     <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
     <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
     <TextBlock Text="Instance Manager Rights:" FontSize="16"/>
-    <Grid IsEnabled="{Binding PageContext.ActiveObject.PermissionSetViewModel.CanEditRights}">
+    <Grid IsEnabled="{Binding PermissionSetViewModel.CanEditRights}">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="1*"/>
         <ColumnDefinition Width="1*"/>
@@ -57,52 +57,52 @@
         <RowDefinition Height="1*"/>
       </Grid.RowDefinitions>
       <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceRead, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceRead, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Read Info of Accessible Instances" ToolTip.Tip="Accessible means instances they have an instance user for" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceList, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceList, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="View All Instances" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="1" Grid.Row="1" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceDelete, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceDelete, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Detach Instances" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceCreate, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceCreate, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Create new Instances" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="0" Grid.Row="2" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceRename, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceRename, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Rename Instances" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="1" Grid.Row="2" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceRelocate, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceRelocate, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Relocate Instances" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="0" Grid.Row="3" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceOnline, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceOnline, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Online and Offline Instances" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="1" Grid.Row="3" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceConfig, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceConfig, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Change Instance Configuration Modes" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="0" Grid.Row="4" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceUpdate, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceUpdate, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Manage Instance Auto Updating" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="1" Grid.Row="4" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceChatLimit, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceChatLimit, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Set Chat Bot Limits" Margin="5,4,0,0" />
       </DockPanel>
       <DockPanel Grid.Column="0" Grid.Row="5" Margin="2">
-        <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.PermissionSetViewModel.InstanceGrant, Mode=TwoWay}"/>
+        <CheckBox Background="White" IsChecked="{Binding PermissionSetViewModel.InstanceGrant, Mode=TwoWay}"/>
         <TextBlock DockPanel.Dock="Right" Text="Grant Themselves Full Permissions on Instances" Margin="5,4,0,0" />
       </DockPanel>
     </Grid>
     <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
     <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-    <Button Content="Save Permissions" Command="{Binding PageContext.ActiveObject.PermissionSetViewModel.Save}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+    <Button Content="Save Permissions" Command="{Binding PermissionSetViewModel.Save}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
   </StackPanel>
 </UserControl>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Repository.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Repository.xaml
@@ -13,11 +13,11 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Row="1">
-      <Grid IsEnabled="{Binding !PageContext.ActiveObject.Refreshing}">
+      <Grid IsEnabled="{Binding !Refreshing}">
         <Grid.RowDefinitions>
           <RowDefinition Height="Auto"/>
           <RowDefinition Height="Auto"/>
@@ -35,44 +35,44 @@
             <ColumnDefinition Width="100"/>
           </Grid.ColumnDefinitions>
           <TextBlock Grid.Column="0" Text="Repository" FontSize="26"/>
-          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Refreshing}" Margin="0,0,5,0"/>
-          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.error.png" IsVisible="{Binding PageContext.ActiveObject.Error}" Margin="0,0,5,0"/>
-          <TextBlock Grid.Column="2" Text="{Binding PageContext.ActiveObject.ErrorMessage}" IsVisible="{Binding PageContext.ActiveObject.Error}" Margin="0,10,0,0"/>
-          <Button Grid.Column="3" Content="Refresh" Command="{Binding PageContext.ActiveObject.RefreshCommand}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Refreshing}" Margin="0,0,5,0"/>
+          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.error.png" IsVisible="{Binding Error}" Margin="0,0,5,0"/>
+          <TextBlock Grid.Column="2" Text="{Binding ErrorMessage}" IsVisible="{Binding Error}" Margin="0,10,0,0"/>
+          <Button Grid.Column="3" Content="Refresh" Command="{Binding RefreshCommand}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
-        <StackPanel Orientation="Vertical" IsVisible="{Binding !PageContext.ActiveObject.CloneAvailable}" Grid.Row="1">
+        <StackPanel Orientation="Vertical" IsVisible="{Binding !CloneAvailable}" Grid.Row="1">
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="Origin URL:"/>
-            <TextBlock Text="{Binding PageContext.ActiveObject.Repository.Origin}" Margin="5,0,0,0"/>
+            <TextBlock Text="{Binding Repository.Origin}" Margin="5,0,0,0"/>
           </StackPanel>
           <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
             <TextBlock Text="Sha:"/>
-            <TextBlock Text="{Binding PageContext.ActiveObject.Repository.RevisionInformation.CommitSha}" Margin="5,0,0,0"/>
+            <TextBlock Text="{Binding Repository.RevisionInformation.CommitSha}" Margin="5,0,0,0"/>
           </StackPanel>
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="Closest Origin Sha:"/>
-            <TextBlock Text="{Binding PageContext.ActiveObject.Repository.RevisionInformation.OriginCommitSha}" Margin="5,0,0,0"/>
+            <TextBlock Text="{Binding Repository.RevisionInformation.OriginCommitSha}" Margin="5,0,0,0"/>
           </StackPanel>
           <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
             <TextBlock Text="Reference:"/>
-            <TextBlock Text="{Binding PageContext.ActiveObject.Repository.Reference}" Margin="5,0,0,0"/>
+            <TextBlock Text="{Binding Repository.Reference}" Margin="5,0,0,0"/>
           </StackPanel>
           <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
             <TextBlock Text="Committer Name:"/>
-            <TextBlock Text="{Binding PageContext.ActiveObject.Repository.CommitterName}" Margin="5,0,0,0"/>
+            <TextBlock Text="{Binding Repository.CommitterName}" Margin="5,0,0,0"/>
           </StackPanel>
           <StackPanel Orientation="Horizontal">
             <TextBlock Text="Committer E-Mail:"/>
-            <TextBlock Text="{Binding PageContext.ActiveObject.Repository.CommitterEmail}" Margin="5,0,0,0"/>
+            <TextBlock Text="{Binding Repository.CommitterEmail}" Margin="5,0,0,0"/>
           </StackPanel>
           <DockPanel LastChildFill="False" Margin="0,5,0,0">
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
               <TextBlock Text="Credentials:"/>
-              <TextBlock Text="{Binding PageContext.ActiveObject.Repository.AccessUser}" Margin="5,0,0,0"/>
+              <TextBlock Text="{Binding Repository.AccessUser}" Margin="5,0,0,0"/>
             </StackPanel>
-            <Button Command="{Binding PageContext.ActiveObject.RemoveCredentials}" Content="Clear Credentials" IsVisible="{Binding PageContext.ActiveObject.HasCredentials}" DockPanel.Dock="Right"/>
+            <Button Command="{Binding RemoveCredentials}" Content="Clear Credentials" IsVisible="{Binding HasCredentials}" DockPanel.Dock="Right"/>
           </DockPanel>
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -86,9 +86,9 @@
               <ColumnDefinition Width="400"/>
             </Grid.ColumnDefinitions>
             <TextBlock Text="Checkout Sha:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.NewSha, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanSetSha}"/>
+            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding NewSha, Mode=TwoWay}" IsEnabled="{Binding CanSetSha}"/>
             <TextBlock Text="Checkout Reference:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
-            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.NewReference, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanSetRef}"/>
+            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding NewReference, Mode=TwoWay}" IsEnabled="{Binding CanSetRef}"/>
           </Grid>
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -102,9 +102,9 @@
               <ColumnDefinition Width="400"/>
             </Grid.ColumnDefinitions>
             <TextBlock Text="Committer Name:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.NewCommitterName, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanChangeCommitter}"/>
+            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding NewCommitterName, Mode=TwoWay}" IsEnabled="{Binding CanChangeCommitter}"/>
             <TextBlock Text="Committer E-Mail:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
-            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.NewCommitterEmail, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanChangeCommitter}"/>
+            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding NewCommitterEmail, Mode=TwoWay}" IsEnabled="{Binding CanChangeCommitter}"/>
           </Grid>
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -119,16 +119,16 @@
               <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.NewAutoUpdatesKeepTestMerges, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanAutoUpdate}" ToolTip.Tip="Enabling this may cause automatic updates to fail due to merge conflicts" />
+              <CheckBox Background="White" IsChecked="{Binding NewAutoUpdatesKeepTestMerges, Mode=TwoWay}" IsEnabled="{Binding CanAutoUpdate}" ToolTip.Tip="Enabling this may cause automatic updates to fail due to merge conflicts" />
               <TextBlock DockPanel.Dock="Right" Text="Automatic Updates Maintain Test Merges" ToolTip.Tip="Enabling this may cause automatic updates to fail due to merge conflicts" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.NewAutoUpdatesSynchronize, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanAutoUpdate}"/>
+              <CheckBox Background="White" IsChecked="{Binding NewAutoUpdatesSynchronize, Mode=TwoWay}" IsEnabled="{Binding CanAutoUpdate}"/>
               <TextBlock DockPanel.Dock="Right" Text="Push Test Merge Commits to Temporary Branch" Margin="5,4,0,0" />
             </DockPanel>
-            <CheckBox Background="White" Content="Show Merger Usernames in Public Metadata" IsChecked="{Binding PageContext.ActiveObject.NewShowTestMergeCommitters, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanShowTMCommitters}" Grid.Column="0" Grid.Row="1"/>
-            <CheckBox Background="White" Content="Post GitHub comment when test merge is deployed" IsChecked="{Binding PageContext.ActiveObject.NewPostTestMergeComment, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanShowTMCommitters}" Grid.Column="1" Grid.Row="1"/>
-            <CheckBox Background="White" Content="Create GitHub Deployment Statuses" IsChecked="{Binding PageContext.ActiveObject.NewGitHubDeployments, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanShowTMCommitters}" Grid.Column="0" Grid.Row="2"/>
+            <CheckBox Background="White" Content="Show Merger Usernames in Public Metadata" IsChecked="{Binding NewShowTestMergeCommitters, Mode=TwoWay}" IsEnabled="{Binding CanShowTMCommitters}" Grid.Column="0" Grid.Row="1"/>
+            <CheckBox Background="White" Content="Post GitHub comment when test merge is deployed" IsChecked="{Binding NewPostTestMergeComment, Mode=TwoWay}" IsEnabled="{Binding CanShowTMCommitters}" Grid.Column="1" Grid.Row="1"/>
+            <CheckBox Background="White" Content="Create GitHub Deployment Statuses" IsChecked="{Binding NewGitHubDeployments, Mode=TwoWay}" IsEnabled="{Binding CanShowTMCommitters}" Grid.Column="0" Grid.Row="2"/>
           </Grid>
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" Grid.Row="2"/>
@@ -143,14 +143,14 @@
             <ColumnDefinition Width="400"/>
           </Grid.ColumnDefinitions>
           <TextBlock Text="Repository Access Username:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.NewAccessUser, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanAccess}"/>
+          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding NewAccessUser, Mode=TwoWay}" IsEnabled="{Binding CanAccess}"/>
           <TextBlock Text="Personal Access Token (repo scope) or Password for Non-GitHub Repos:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
-          <TextBox Grid.Column="1" PasswordChar="*" Grid.Row="1" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.NewAccessToken, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanAccess}"/>
+          <TextBox Grid.Column="1" PasswordChar="*" Grid.Row="1" Margin="50,0,0,5" Text="{Binding NewAccessToken, Mode=TwoWay}" IsEnabled="{Binding CanAccess}"/>
         </Grid>
-        <StackPanel Orientation="Vertical" IsVisible="{Binding PageContext.ActiveObject.CloneAvailable}" Grid.Row="5">
+        <StackPanel Orientation="Vertical" IsVisible="{Binding CloneAvailable}" Grid.Row="5">
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-          <Grid IsEnabled="{Binding PageContext.ActiveObject.CanClone}">
+          <Grid IsEnabled="{Binding CanClone}">
             <Grid.RowDefinitions>
               <RowDefinition Height="Auto"/>
               <RowDefinition Height="Auto"/>
@@ -162,11 +162,11 @@
               <ColumnDefinition Width="400"/>
             </Grid.ColumnDefinitions>
             <TextBlock Text="Repository URL:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.NewOrigin, Mode=TwoWay}"/>
+            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding NewOrigin, Mode=TwoWay}"/>
             <TextBlock Text="Branch (Empty for default):" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
-            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding PageContext.ActiveObject.NewReference, Mode=TwoWay}"/>
+            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding NewReference, Mode=TwoWay}"/>
             <TextBlock Text="Recurse Submodules:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="2" />
-            <CheckBox Background="White" Grid.Column="1" Grid.Row="2" IsChecked="{Binding PageContext.ActiveObject.RecurseSubmodules, Mode=TwoWay}"/>
+            <CheckBox Background="White" Grid.Column="1" Grid.Row="2" IsChecked="{Binding RecurseSubmodules, Mode=TwoWay}"/>
           </Grid>
           <Grid>
             <Grid.ColumnDefinitions>
@@ -174,10 +174,10 @@
               <ColumnDefinition Width="20*"/>
               <ColumnDefinition Width="40*"/>
             </Grid.ColumnDefinitions>
-            <Button Command="{Binding PageContext.ActiveObject.Clone}" Content="Clone" Grid.Column="1"/>
+            <Button Command="{Binding Clone}" Content="Clone" Grid.Column="1"/>
           </Grid>
         </StackPanel>
-        <Grid IsVisible="{Binding !PageContext.ActiveObject.CloneAvailable}" Grid.Row="6">
+        <Grid IsVisible="{Binding !CloneAvailable}" Grid.Row="6">
           <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -201,15 +201,15 @@
               <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.UpdateMerge, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanUpdateMerge}"/>
+              <CheckBox Background="White" IsChecked="{Binding UpdateMerge, Mode=TwoWay}" IsEnabled="{Binding CanUpdateMerge}"/>
               <TextBlock DockPanel.Dock="Right" Text="Merge From Tracked Origin Reference" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.UpdateHard, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanUpdate}"/>
-              <TextBlock DockPanel.Dock="Right" Text="{Binding PageContext.ActiveObject.UpdateText}" Margin="5,4,0,0" />
+              <CheckBox Background="White" IsChecked="{Binding UpdateHard, Mode=TwoWay}" IsEnabled="{Binding CanUpdate}"/>
+              <TextBlock DockPanel.Dock="Right" Text="{Binding UpdateText}" Margin="5,4,0,0" />
             </DockPanel>
             <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding PageContext.ActiveObject.DeployAfter, Mode=TwoWay}" IsEnabled="{Binding PageContext.ActiveObject.CanDeploy}"/>
+              <CheckBox Background="White" IsChecked="{Binding DeployAfter, Mode=TwoWay}" IsEnabled="{Binding CanDeploy}"/>
               <TextBlock DockPanel.Dock="Right" Text="Deploy Code After Changes" Margin="5,4,0,0" />
             </DockPanel>
           </Grid>
@@ -226,8 +226,8 @@
               <ColumnDefinition Width="20*"/>
               <ColumnDefinition Width="10*"/>
             </Grid.ColumnDefinitions>
-            <Button Content="Apply Changes" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Update}" Margin="0,0,5,0" />
-            <Button Content="{Binding PageContext.ActiveObject.DeleteText}" Grid.Column="3" Command="{Binding PageContext.ActiveObject.Delete}" Margin="0,0,5,0" />
+            <Button Content="Apply Changes" Grid.Column="1" Command="{Binding Update}" Margin="0,0,5,0" />
+            <Button Content="{Binding DeleteText}" Grid.Column="3" Command="{Binding Delete}" Margin="0,0,5,0" />
           </Grid>
         </Grid>
       </Grid>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/StaticAdd.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/StaticAdd.xaml
@@ -9,13 +9,13 @@
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="Auto" />
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White" Grid.Column="0" />
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White" Grid.Column="0" />
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="{Binding PageContext.ActiveObject.DetailTitle}" FontSize="26" />
-        <TextBlock IsVisible="{Binding PageContext.ActiveObject.Errored}" Text="{Binding PageContext.ActiveObject.ErrorMessage}" />
+        <TextBlock Grid.Column="0" Grid.Row="0" Text="{Binding DetailTitle}" FontSize="26" />
+        <TextBlock IsVisible="{Binding Errored}" Text="{Binding ErrorMessage}" />
         <Grid Margin="0,5,0,0">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
@@ -23,7 +23,7 @@
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
           <TextBlock Text="Item Type:" Grid.Column="0" Margin="0,5,0,0" />
-          <ComboBox SelectedIndex="{Binding PageContext.ActiveObject.Type, Mode=TwoWay}" Grid.Column="1" Margin="5,0,0,0">
+          <ComboBox SelectedIndex="{Binding Type, Mode=TwoWay}" Grid.Column="1" Margin="5,0,0,0">
             <ComboBoxItem>File</ComboBoxItem>
             <ComboBoxItem>Directory</ComboBoxItem>
           </ComboBox>
@@ -34,9 +34,9 @@
             <ColumnDefinition Width="200" />
           </Grid.ColumnDefinitions>
           <TextBlock Text="Item Name:" Grid.Column="0" Margin="0,5,0,0" />
-          <TextBox Text="{Binding PageContext.ActiveObject.ItemName, Mode=TwoWay}" Grid.Column="1" Margin="5,0,0,0" />
+          <TextBox Text="{Binding ItemName, Mode=TwoWay}" Grid.Column="1" Margin="5,0,0,0" />
         </Grid>
-        <StackPanel Orientation="Vertical" IsVisible="{Binding !PageContext.ActiveObject.IsDirectory}" Margin="5">
+        <StackPanel Orientation="Vertical" IsVisible="{Binding !IsDirectory}" Margin="5">
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" />
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" />
           <Grid>
@@ -49,8 +49,8 @@
               <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <TextBlock Text="Upload From File:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0" />
-            <TextBox Text="{Binding PageContext.ActiveObject.ItemPath}" Grid.Column="1" Margin="5,0,0,0" Grid.Row="0" />
-            <Button Content="..." Command="{Binding PageContext.ActiveObject.Browse}" Grid.Column="2" Grid.Row="0" />
+            <TextBox Text="{Binding ItemPath}" Grid.Column="1" Margin="5,0,0,0" Grid.Row="0" />
+            <Button Content="..." Command="{Binding Browse}" Grid.Column="2" Grid.Row="0" />
           </Grid>
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" />
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" />
@@ -58,7 +58,7 @@
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" />
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" />
           <TextBlock Text="Edit Text" FontSize="20" />
-          <TextBox TextWrapping="Wrap" AcceptsReturn="True" Text="{Binding PageContext.ActiveObject.ItemText}" Height="500" />
+          <TextBox TextWrapping="Wrap" AcceptsReturn="True" Text="{Binding ItemText}" Height="500" />
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" />
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" />
@@ -68,7 +68,7 @@
             <ColumnDefinition Width="2*" />
             <ColumnDefinition Width="5*" />
           </Grid.ColumnDefinitions>
-          <Button Content="Create" Command="{Binding PageContext.ActiveObject.Add}" Grid.Column="1" />
+          <Button Content="Create" Command="{Binding Add}" Grid.Column="1" />
         </Grid>
       </StackPanel>
     </ScrollViewer>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/StaticFile.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/StaticFile.xaml
@@ -9,8 +9,8 @@
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="Auto" />
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White" Grid.Column="0" />
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White" Grid.Column="0" />
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -27,10 +27,10 @@
           <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
           </Grid.RowDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" Text="{Binding PageContext.ActiveObject.Path}" FontSize="26" />
-          <TextBlock IsVisible="{Binding PageContext.ActiveObject.Errored}" Text="{Binding PageContext.ActiveObject.ErrorMessage}" Grid.Column="5" Margin="0,5,0,0" />
-          <Image Grid.Column="4" Grid.Row="0" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Refreshing}" Margin="0,0,5,0" />
-          <Button Grid.Column="6" Grid.Row="0" Content="Refresh" Command="{Binding PageContext.ActiveObject.Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD" />
+          <TextBlock Grid.Column="0" Grid.Row="0" Text="{Binding Path}" FontSize="26" />
+          <TextBlock IsVisible="{Binding Errored}" Text="{Binding ErrorMessage}" Grid.Column="5" Margin="0,5,0,0" />
+          <Image Grid.Column="4" Grid.Row="0" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Refreshing}" Margin="0,0,5,0" />
+          <Button Grid.Column="6" Grid.Row="0" Content="Refresh" Command="{Binding Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD" />
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" />
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" />
@@ -47,30 +47,30 @@
             <RowDefinition Height="Auto" />
           </Grid.RowDefinitions>
           <TextBlock Text="Upload From File:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0" />
-          <TextBox Text="{Binding PageContext.ActiveObject.UploadPath}" Grid.Column="1" Margin="5,0,0,0" Grid.Row="0" />
-          <Button Content="..." Command="{Binding PageContext.ActiveObject.BrowseUpload}" Grid.Column="2" Grid.Row="0" />
-          <Button Content="Upload" Command="{Binding PageContext.ActiveObject.Upload}" Grid.Column="3" Grid.Row="0" Margin="5,0,0,0" />
+          <TextBox Text="{Binding UploadPath}" Grid.Column="1" Margin="5,0,0,0" Grid.Row="0" />
+          <Button Content="..." Command="{Binding BrowseUpload}" Grid.Column="2" Grid.Row="0" />
+          <Button Content="Upload" Command="{Binding Upload}" Grid.Column="3" Grid.Row="0" Margin="5,0,0,0" />
           <TextBlock Text="Save To File:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="2" />
-          <TextBox Text="{Binding PageContext.ActiveObject.DownloadPath}" Grid.Column="1" Margin="5,0,0,0" Grid.Row="2" />
-          <Button Content="..." Command="{Binding PageContext.ActiveObject.BrowseDownload}" Grid.Row="2" Grid.Column="2" />
-          <Button Content="Save" Command="{Binding PageContext.ActiveObject.Download}" Grid.Column="3" Grid.Row="2" Margin="5,0,0,0" />
+          <TextBox Text="{Binding DownloadPath}" Grid.Column="1" Margin="5,0,0,0" Grid.Row="2" />
+          <Button Content="..." Command="{Binding BrowseDownload}" Grid.Row="2" Grid.Column="2" />
+          <Button Content="Save" Command="{Binding Download}" Grid.Column="3" Grid.Row="2" Margin="5,0,0,0" />
         </Grid>
-        <StackPanel Orientation="Vertical" IsVisible="{Binding PageContext.ActiveObject.IsText}" Margin="5">
+        <StackPanel Orientation="Vertical" IsVisible="{Binding IsText}" Margin="5">
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" />
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" />
           <TextBlock Text="OR" HorizontalAlignment="Center" />
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" />
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" />
           <TextBlock Text="Edit Text" FontSize="20" />
-          <Button Content="Enable Text Editor" Command="{Binding PageContext.ActiveObject.EnableEditor}" IsVisible="{Binding !PageContext.ActiveObject.EditorEnabled}" />
-          <TextBox TextWrapping="Wrap" AcceptsReturn="True" Text="{Binding PageContext.ActiveObject.TextBlob}" MinHeight="500" IsVisible="{Binding PageContext.ActiveObject.EditorEnabled}" />
+          <Button Content="Enable Text Editor" Command="{Binding EnableEditor}" IsVisible="{Binding !EditorEnabled}" />
+          <TextBox TextWrapping="Wrap" AcceptsReturn="True" Text="{Binding TextBlob}" MinHeight="500" IsVisible="{Binding EditorEnabled}" />
           <Grid>
             <Grid.ColumnDefinitions>
               <ColumnDefinition Width="5*" />
               <ColumnDefinition Width="2*" />
               <ColumnDefinition Width="5*" />
             </Grid.ColumnDefinitions>
-            <Button Content="Save" Command="{Binding PageContext.ActiveObject.Write}" Grid.Column="1" Margin="0,5,0,0" IsVisible="{Binding PageContext.ActiveObject.EditorEnabled}" />
+            <Button Content="Save" Command="{Binding Write}" Grid.Column="1" Margin="0,5,0,0" IsVisible="{Binding EditorEnabled}" />
           </Grid>
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" />
@@ -81,7 +81,7 @@
             <ColumnDefinition Width="2*" />
             <ColumnDefinition Width="5*" />
           </Grid.ColumnDefinitions>
-          <Button Content="{Binding PageContext.ActiveObject.DeleteText}" Command="{Binding PageContext.ActiveObject.Delete}" Grid.Column="1" />
+          <Button Content="{Binding DeleteText}" Command="{Binding Delete}" Grid.Column="1" />
         </Grid>
       </StackPanel>
     </ScrollViewer>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/StaticFolder.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/StaticFolder.xaml
@@ -9,8 +9,8 @@
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="Auto" />
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White" Grid.Column="0" />
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White" Grid.Column="0" />
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <Grid>
@@ -28,11 +28,11 @@
           <RowDefinition Height="5" />
           <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="{Binding PageContext.ActiveObject.Path}" FontSize="26" />
-        <Image Grid.Column="4" Grid.Row="0" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Refreshing}" Margin="0,0,5,0" />
-        <TextBlock IsVisible="{Binding PageContext.ActiveObject.Errored}" Text="{Binding PageContext.ActiveObject.ErrorMessage}" Grid.Column="5" Margin="0,5,0,0" />
-        <Button Grid.Column="6" Grid.Row="0" Content="Refresh" Command="{Binding PageContext.ActiveObject.Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD" />
-        <Button Grid.Column="2" Grid.Row="2" Content="Delete If Empty" Command="{Binding PageContext.ActiveObject.Delete}" />
+        <TextBlock Grid.Column="0" Grid.Row="0" Text="{Binding Path}" FontSize="26" />
+        <Image Grid.Column="4" Grid.Row="0" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Refreshing}" Margin="0,0,5,0" />
+        <TextBlock IsVisible="{Binding Errored}" Text="{Binding ErrorMessage}" Grid.Column="5" Margin="0,5,0,0" />
+        <Button Grid.Column="6" Grid.Row="0" Content="Refresh" Command="{Binding Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD" />
+        <Button Grid.Column="2" Grid.Row="2" Content="Delete If Empty" Command="{Binding Delete}" />
       </Grid>
     </ScrollViewer>
   </Grid>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml
@@ -8,8 +8,8 @@
     </Grid.RowDefinitions>
     <DockPanel Margin="0,0,0,10" LastChildFill="False" Grid.Row="0">
       <TextBlock Text="Test Merges" FontSize="20" DockPanel.Dock="Left"/>
-      <Button Content="Refresh" Command="{Binding PageContext.ActiveObject.RefreshPRs}" DockPanel.Dock="Right"/>
-      <TextBlock Text="{Binding PageContext.ActiveObject.RateLimitSeconds}" IsVisible="{Binding PageContext.ActiveObject.RateLimited}" DockPanel.Dock="Right" Margin="0,5,5,0"/>
+      <Button Content="Refresh" Command="{Binding RefreshPRs}" DockPanel.Dock="Right"/>
+      <TextBlock Text="{Binding RateLimitSeconds}" IsVisible="{Binding RateLimited}" DockPanel.Dock="Right" Margin="0,5,5,0"/>
     </DockPanel>
     <Grid Grid.Column="1" Grid.Row="1">
       <Grid.ColumnDefinitions>
@@ -22,7 +22,7 @@
         <RowDefinition Height="Auto"/>
       </Grid.RowDefinitions>
       <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="#FFFFFF" Grid.Row="0" Grid.Column="1">
-        <ItemsControl Items="{Binding PageContext.ActiveObject.TestMerges}">
+        <ItemsControl Items="{Binding TestMerges}">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
               <Panel Background="#000000">
@@ -69,8 +69,8 @@
           <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
         <TextBlock Text="Manual Add PR#:" Margin="0,5,5,0" Grid.Column="0"/>
-        <NumericUpDown Minimum="1" Value="{Binding PageContext.ActiveObject.ManualPR}" Margin="0,0,5,0" Grid.Column="1"/>
-        <Button Content="Add" Command="{Binding PageContext.ActiveObject.DirectAddPR}" Grid.Column="2"/>
+        <NumericUpDown Minimum="1" Value="{Binding ManualPR}" Margin="0,0,5,0" Grid.Column="1"/>
+        <Button Content="Add" Command="{Binding DirectAddPR}" Grid.Column="2"/>
       </Grid>
     </Grid>
   </Grid>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/UserManager.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/UserManager.xaml
@@ -12,8 +12,8 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Grid.Row="1">
       <StackPanel Orientation="Vertical">
@@ -23,38 +23,38 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="100"/>
           </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.User.Name}" FontSize="26"/>
-          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Refreshing}" Margin="0,0,5,0"/>
-          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.error.png" IsVisible="{Binding PageContext.ActiveObject.Error}" Margin="0,0,5,0"/>
-          <Button Grid.Column="2" Content="Refresh" Command="{Binding PageContext.ActiveObject.Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <TextBlock Grid.Column="0" Text="{Binding User.Name}" FontSize="26"/>
+          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Refreshing}" Margin="0,0,5,0"/>
+          <Image Grid.Column="1" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.error.png" IsVisible="{Binding Error}" Margin="0,0,5,0"/>
+          <Button Grid.Column="2" Content="Refresh" Command="{Binding Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="ID:"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.User.Id}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding User.Id}" Margin="5,0,0,0"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Created on:"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.User.CreatedAt}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding User.CreatedAt}" Margin="5,0,0,0"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="Created by:"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.FormatCreatedBy}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding FormatCreatedBy}" Margin="5,0,0,0"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
           <TextBlock Text="System Identifier:"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.User.SystemIdentifier}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding User.SystemIdentifier}" Margin="5,0,0,0"/>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" IsVisible="{Binding PageContext.ActiveObject.IsGroupedUser}">
+        <StackPanel Orientation="Horizontal" IsVisible="{Binding IsGroupedUser}">
           <TextBlock Text="Group:"/>
-          <TextBlock Text="{Binding PageContext.ActiveObject.User.Group.Name}" Margin="5,0,0,0"/>
+          <TextBlock Text="{Binding User.Group.Name}" Margin="5,0,0,0"/>
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
         <StackPanel Orientation="Horizontal">
-          <CheckBox Background="White" IsEnabled="{Binding PageContext.ActiveObject.CanEditRights}" IsChecked="{Binding PageContext.ActiveObject.Enabled, Mode=TwoWay}"/>
+          <CheckBox Background="White" IsEnabled="{Binding CanEditRights}" IsChecked="{Binding Enabled, Mode=TwoWay}"/>
           <TextBlock DockPanel.Dock="Right" Text="Enabled" Margin="5,4,0,0" />
         </StackPanel>
-        <StackPanel Orientation="Vertical" IsVisible="{Binding !PageContext.ActiveObject.IsSystemUser}">
+        <StackPanel Orientation="Vertical" IsVisible="{Binding !IsSystemUser}">
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
           <Grid>
@@ -67,19 +67,19 @@
               <ColumnDefinition Width="400"/>
             </Grid.ColumnDefinitions>
             <TextBlock Text="New Password:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-            <TextBox PasswordChar="*" Watermark="{Binding PageContext.ActiveObject.PasswordLength}" Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" IsEnabled="{Binding PageContext.ActiveObject.CanEditPassword}" Text="{Binding PageContext.ActiveObject.NewPassword, Mode=TwoWay}"/>
+            <TextBox PasswordChar="*" Watermark="{Binding PasswordLength}" Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" IsEnabled="{Binding CanEditPassword}" Text="{Binding NewPassword, Mode=TwoWay}"/>
             <TextBlock Text="Confirm Password:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
-            <TextBox PasswordChar="*" Watermark="{Binding PageContext.ActiveObject.PasswordLength}" Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" IsEnabled="{Binding PageContext.ActiveObject.CanEditPassword}" Text="{Binding PageContext.ActiveObject.PasswordConfirm, Mode=TwoWay}"/>
+            <TextBox PasswordChar="*" Watermark="{Binding PasswordLength}" Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" IsEnabled="{Binding CanEditPassword}" Text="{Binding PasswordConfirm, Mode=TwoWay}"/>
           </Grid>
-          <Button Content="Save User Settings" Command="{Binding PageContext.ActiveObject.Save}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Button Content="Save User Settings" Command="{Binding Save}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
 
-          <StackPanel Orientation="Vertical" IsVisible="{Binding PageContext.ActiveObject.IsGroupedUser}">
+          <StackPanel Orientation="Vertical" IsVisible="{Binding IsGroupedUser}">
             <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
             <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-            <Button Content="Remove User From Group" Command="{Binding PageContext.ActiveObject.RemoveFromGroup}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+            <Button Content="Remove User From Group" Command="{Binding RemoveFromGroup}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
           </StackPanel>
         </StackPanel>
-        <local:PermissionSet IsVisible="{Binding !PageContext.ActiveObject.IsGroupedUser}" Grid.Row="5"/>
+        <local:PermissionSet IsVisible="{Binding !IsGroupedUser}" Grid.Row="5"/>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Watchdog.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Watchdog.xaml
@@ -12,11 +12,11 @@
         <ColumnDefinition Width="*"/>
         <ColumnDefinition Width="Auto"/>
       </Grid.ColumnDefinitions>
-      <TextBlock DockPanel.Dock="Left" Text="{Binding PageContext.ActiveObject.Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
-      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding PageContext.ActiveObject.Close}" Margin="0,0,5,0" />
+      <TextBlock DockPanel.Dock="Left" Text="{Binding Title}" Margin="3" Foreground="White"  Grid.Column="0"/>
+      <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Row="1">
-      <StackPanel Orientation="Vertical" IsEnabled="{Binding !PageContext.ActiveObject.Refreshing}">
+      <StackPanel Orientation="Vertical" IsEnabled="{Binding !Refreshing}">
         <Grid >
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -25,42 +25,42 @@
             <ColumnDefinition Width="150"/>
           </Grid.ColumnDefinitions>
           <TextBlock Grid.Column="0" Text="Dream Daemon" FontSize="26" />
-          <Image Grid.Column="2" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding PageContext.ActiveObject.Refreshing}" Margin="0,0,5,0"/>
-          <Button Grid.Column="3" Content="Refresh" Command="{Binding PageContext.ActiveObject.Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
+          <Image Grid.Column="2" Width="20" Height="20" Source="resm:Tgstation.Server.ControlPanel.Assets.hourglass.blue_back.png" IsVisible="{Binding Refreshing}" Margin="0,0,5,0"/>
+          <Button Grid.Column="3" Content="Refresh" Command="{Binding Refresh}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
         <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
           <TextBlock Grid.Column="0" Text="Status:" FontSize="20" />
-          <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.StatusString}" Foreground="{Binding PageContext.ActiveObject.StatusColour}" FontSize="20" Margin="5,0,0,0"/>
+          <TextBlock Grid.Column="0" Text="{Binding StatusString}" Foreground="{Binding StatusColour}" FontSize="20" Margin="5,0,0,0"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
           <TextBlock Grid.Column="0" Text="Port:" />
-          <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.Port}" Margin="5,0,0,0"/>
+          <TextBlock Grid.Column="0" Text="{Binding Port}" Margin="5,0,0,0"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
           <TextBlock Grid.Column="0" Text="Security Level:"/>
-          <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.CurrentSecurity}" Margin="5,0,0,0"/>
+          <TextBlock Grid.Column="0" Text="{Binding CurrentSecurity}" Margin="5,0,0,0"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
           <TextBlock Grid.Column="0" Text="Web Client Allowed:"/>
-          <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.WebClient}" Margin="5,0,0,0"/>
+          <TextBlock Grid.Column="0" Text="{Binding WebClient}" Margin="5,0,0,0"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
           <TextBlock Grid.Column="0" Text="Graceful Action:"/>
-          <TextBlock Grid.Column="0" Text="{Binding PageContext.ActiveObject.Graceful}" Margin="5,0,0,0"/>
+          <TextBlock Grid.Column="0" Text="{Binding Graceful}" Margin="5,0,0,0"/>
         </StackPanel>
-        <StackPanel Orientation="Vertical" IsVisible="{Binding PageContext.ActiveObject.HasRevision}">
-          <StackPanel Orientation="Vertical" IsVisible="{Binding PageContext.ActiveObject.HasStagedRevision}">
+        <StackPanel Orientation="Vertical" IsVisible="{Binding HasRevision}">
+          <StackPanel Orientation="Vertical" IsVisible="{Binding HasStagedRevision}">
             <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
             <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
             <TextBlock Text="Staged Deployment"/>
-            <local:CompileJobList DataContext="{Binding PageContext.ActiveObject.StagedCompileJob}" />
+            <local:CompileJobList DataContext="{Binding StagedCompileJob}" />
           </StackPanel>
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
           <TextBlock Text="Active Deployment"/>
-          <local:CompileJobList DataContext="{Binding PageContext.ActiveObject.ActiveCompileJob}" />
+          <local:CompileJobList DataContext="{Binding ActiveCompileJob}" />
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -84,17 +84,17 @@
             <RowDefinition Height="Auto"/>
           </Grid.RowDefinitions>
           <TextBlock Text="Public Game Port:" Grid.Row="0" Grid.Column="0"/>
-          <NumericUpDown Minimum="1" Maximum="65535"  IsEnabled="{Binding PageContext.ActiveObject.CanPort}" Value="{Binding PageContext.ActiveObject.NewPrimaryPort}" Grid.Row="0" Grid.Column="1"/>
-          <CheckBox Content="Allow Web Client Connections" Grid.Column="0" Grid.Row="3" IsChecked="{Binding PageContext.ActiveObject.NewAllowWebClient}" IsEnabled="{Binding PageContext.ActiveObject.CanWebClient}" Background="White"/>
-          <CheckBox Content="Automatically Start Server with Instance" Grid.Column="1" Grid.Row="3" IsChecked="{Binding PageContext.ActiveObject.NewAutoStart}" IsEnabled="{Binding PageContext.ActiveObject.CanAutoStart}" Background="White"/>
+          <NumericUpDown Minimum="1" Maximum="65535"  IsEnabled="{Binding CanPort}" Value="{Binding NewPrimaryPort}" Grid.Row="0" Grid.Column="1"/>
+          <CheckBox Content="Allow Web Client Connections" Grid.Column="0" Grid.Row="3" IsChecked="{Binding NewAllowWebClient}" IsEnabled="{Binding CanWebClient}" Background="White"/>
+          <CheckBox Content="Automatically Start Server with Instance" Grid.Column="1" Grid.Row="3" IsChecked="{Binding NewAutoStart}" IsEnabled="{Binding CanAutoStart}" Background="White"/>
           <TextBlock Text="Launch Inactivity Timeout Period (seconds):" Margin="0,5,5,0" Grid.Column="0" Grid.Row="5"/>
-          <NumericUpDown Minimum="1" Value="{Binding PageContext.ActiveObject.NewStartupTimeout}" Grid.Column="1" Grid.Row="5" IsEnabled="{Binding PageContext.ActiveObject.CanTimeout}" />
+          <NumericUpDown Minimum="1" Value="{Binding NewStartupTimeout}" Grid.Column="1" Grid.Row="5" IsEnabled="{Binding CanTimeout}" />
           <TextBlock Text="Heartbeat Seconds (0 disables):" ToolTip.Tip="Heartbeats are TGS checking on DD's status via /world/Topic. If 4 are missed, an automatic restart will occur." Margin="0,5,5,0" Grid.Column="0" Grid.Row="7"/>
-          <NumericUpDown Minimum="0" ToolTip.Tip="Heartbeats are TGS checking on DD's status via /world/Topic. If 4 are missed, an automatic restart will occur." Value="{Binding PageContext.ActiveObject.NewHeartbeatSeconds}" Grid.Column="1" Grid.Row="7" IsEnabled="{Binding PageContext.ActiveObject.CanHeartbeat}" />
+          <NumericUpDown Minimum="0" ToolTip.Tip="Heartbeats are TGS checking on DD's status via /world/Topic. If 4 are missed, an automatic restart will occur." Value="{Binding NewHeartbeatSeconds}" Grid.Column="1" Grid.Row="7" IsEnabled="{Binding CanHeartbeat}" />
           <TextBlock Text="Timeout For Sending BYOND Topics (Milliseconds):" ToolTip.Tip="TGS communicates to DreamDaemon via invoking /world/Topic with forged packets. This is the timeout for all of those operations." Margin="0,5,5,0" Grid.Column="0" Grid.Row="9"/>
-          <NumericUpDown Minimum="1" ToolTip.Tip="TGS communicates to DreamDaemon via invoking /world/Topic with forged packets. This is the timeout for all of those operations.." Value="{Binding PageContext.ActiveObject.NewTopicTimeout}" Grid.Column="1" Grid.Row="9" IsEnabled="{Binding PageContext.ActiveObject.CanTopic}" />
+          <NumericUpDown Minimum="1" ToolTip.Tip="TGS communicates to DreamDaemon via invoking /world/Topic with forged packets. This is the timeout for all of those operations.." Value="{Binding NewTopicTimeout}" Grid.Column="1" Grid.Row="9" IsEnabled="{Binding CanTopic}" />
            <TextBlock Grid.Column="0" Text="Additional Params:" Grid.Row="11"/>
-           <TextBox Text="{Binding PageContext.ActiveObject.NewAdditionalParams}" IsEnabled="{Binding PageContext.ActiveObject.CanAdditionalParams}" Margin="5,0,0,0" Grid.Column="1" Grid.Row="11"/>
+           <TextBox Text="{Binding NewAdditionalParams}" IsEnabled="{Binding CanAdditionalParams}" Margin="5,0,0,0" Grid.Column="1" Grid.Row="11"/>
         </Grid>
         <Grid Margin="0,5,0,0">
           <Grid.RowDefinitions>
@@ -114,12 +114,12 @@
           </Grid.ColumnDefinitions>
           <TextBlock Text="Security Level:" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="7" ToolTip.Tip="Note that the minimum security level specified in deployments can override this setting."/>
           <TextBlock Text="Graceful Action:" ToolTip.Tip="The watchdog action that will be taken when /world/Reboot is called." Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="7" />
-          <RadioButton Content="Ultrasafe" Grid.Row="1" Grid.Column="1" IsChecked="{Binding PageContext.ActiveObject.Ultrasafe}"  ToolTip.Tip="Note that the minimum security level specified in deployments can override this setting."/>
-          <RadioButton Content="Safe" Grid.Row="1" Grid.Column="3" IsChecked="{Binding PageContext.ActiveObject.Safe}"  ToolTip.Tip="Note that the minimum security level specified in deployments can override this setting."/>
-          <RadioButton Content="Trusted" Grid.Row="1" Grid.Column="5" IsChecked="{Binding PageContext.ActiveObject.Trusted}"  ToolTip.Tip="Note that the minimum security level specified in deployments can override this setting."/>
-          <RadioButton GroupName="GA" ToolTip.Tip="The watchdog action that will be taken when /world/Reboot is called." Content="None" Grid.Row="3" Grid.Column="1" IsChecked="{Binding PageContext.ActiveObject.ClearSoft}" IsEnabled="{Binding PageContext.ActiveObject.Model.Running}"/>
-          <RadioButton GroupName="GA" ToolTip.Tip="The watchdog action that will be taken when /world/Reboot is called." Content="Restart" Grid.Row="3" Grid.Column="3" IsChecked="{Binding PageContext.ActiveObject.SoftRestart}" IsEnabled="{Binding PageContext.ActiveObject.Model.Running}" />
-          <RadioButton GroupName="GA" ToolTip.Tip="The watchdog action that will be taken when /world/Reboot is called." Content="Shutdown" Grid.Row="3" Grid.Column="5" IsChecked="{Binding PageContext.ActiveObject.SoftStop}" IsEnabled="{Binding PageContext.ActiveObject.Model.Running}" />
+          <RadioButton Content="Ultrasafe" Grid.Row="1" Grid.Column="1" IsChecked="{Binding Ultrasafe}"  ToolTip.Tip="Note that the minimum security level specified in deployments can override this setting."/>
+          <RadioButton Content="Safe" Grid.Row="1" Grid.Column="3" IsChecked="{Binding Safe}"  ToolTip.Tip="Note that the minimum security level specified in deployments can override this setting."/>
+          <RadioButton Content="Trusted" Grid.Row="1" Grid.Column="5" IsChecked="{Binding Trusted}"  ToolTip.Tip="Note that the minimum security level specified in deployments can override this setting."/>
+          <RadioButton GroupName="GA" ToolTip.Tip="The watchdog action that will be taken when /world/Reboot is called." Content="None" Grid.Row="3" Grid.Column="1" IsChecked="{Binding ClearSoft}" IsEnabled="{Binding Model.Running}"/>
+          <RadioButton GroupName="GA" ToolTip.Tip="The watchdog action that will be taken when /world/Reboot is called." Content="Restart" Grid.Row="3" Grid.Column="3" IsChecked="{Binding SoftRestart}" IsEnabled="{Binding Model.Running}" />
+          <RadioButton GroupName="GA" ToolTip.Tip="The watchdog action that will be taken when /world/Reboot is called." Content="Shutdown" Grid.Row="3" Grid.Column="5" IsChecked="{Binding SoftStop}" IsEnabled="{Binding Model.Running}" />
         </Grid>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
         <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -139,12 +139,12 @@
             <ColumnDefinition Width="20*"/>
             <ColumnDefinition Width="15*"/>
           </Grid.ColumnDefinitions>
-          <Button Content="Apply Changes" Command="{Binding PageContext.ActiveObject.Update}" Grid.Column="1"/>
-          <Button Content="Start Server" Command="{Binding PageContext.ActiveObject.Start}" Grid.Column="3"/>
-          <Button Content="Connect to Server" Command="{Binding PageContext.ActiveObject.Join}" Grid.Column="5"/>
-          <Button Content="Create Process Dump" Command="{Binding PageContext.ActiveObject.Dump}" Grid.Column="7"/>
-          <Button Content="{Binding PageContext.ActiveObject.RestartWord}" Command="{Binding PageContext.ActiveObject.Restart}" Grid.Column="9"/>
-          <Button Content="{Binding PageContext.ActiveObject.StopWord}" Command="{Binding PageContext.ActiveObject.Stop}" Grid.Column="11"/>
+          <Button Content="Apply Changes" Command="{Binding Update}" Grid.Column="1"/>
+          <Button Content="Start Server" Command="{Binding Start}" Grid.Column="3"/>
+          <Button Content="Connect to Server" Command="{Binding Join}" Grid.Column="5"/>
+          <Button Content="Create Process Dump" Command="{Binding Dump}" Grid.Column="7"/>
+          <Button Content="{Binding RestartWord}" Command="{Binding Restart}" Grid.Column="9"/>
+          <Button Content="{Binding StopWord}" Command="{Binding Stop}" Grid.Column="11"/>
         </Grid>
       </StackPanel>
     </ScrollViewer>


### PR DESCRIPTION
Replaces the page pattern in MainView.xaml with DataTemplates, which allows us to avoid the performance hit from maintaining every single non-visible page. As a side effect, each component that was a page has been updated to correct the now-irrelevant PageContext.ActiveObject reference, as the scope has changed.

Entering and leaving the repo view is still noticeably slow, presumably because of all the elements being created and destroyed, but I have another PR coming down the line that hopes to ease that pain.

These changes also necessitated changing how the GitHubToken was passed between the MainWindowViewModel and the ConnectionManagerViewModel; I am now using actions and functions to perform this.

Also fixed Avalonia previews, as they couldn't be generated when the AppBuilder function took any args. Limitation of Avalonia's tooling.

Closes #70 
 