### PR TITLE
Improvements to layout and performance of repository page

### DIFF
--- a/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -480,6 +480,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 		{
 			SelectedTestMerges = TestMerges.Where(x => x.Selected).ToList();
 			AvailableTestMerges = TestMerges.Where(x => !x.Selected).ToList();
+			AddPR.Recheck();
 		}
 
 		void DigestPR(Octokit.Issue pr, IReadOnlyList<Octokit.PullRequestCommit> commits)

--- a/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
@@ -471,6 +471,8 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				RecheckCommands();
 			}
 
+
+
 			return job;
 		}
 

--- a/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/RepositoryViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -578,19 +578,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 						testMergeViewModel.LoadCommitsAction(await gitHubClient.PullRequest.Commits(Repository.RemoteRepositoryOwner, Repository.RemoteRepositoryName, a.Key).ConfigureAwait(false));
 					}
 
-					// Maintain selected status changes between refreshes
-					var selected = false;
-					if (SelectedTestMerges != null)
-					{
-						var tm = SelectedTestMerges.FirstOrDefault(x => x.TestMerge.Number == a.Value.Number);
-						if (tm != null)
-						{
-							selected = tm.Selected;
-						}
-					}
-
-					testMergeViewModel = new TestMergeViewModel(a.Value, b.Value, x => modifiedPRList = true, LoadCommits, selected: selected);
-					return testMergeViewModel;
+					return new TestMergeViewModel(a.Value, b.Value, x => modifiedPRList = true, LoadCommits);
 				}).Where(x => x != null).ToList();
 				tmp.AddRange(enumerable.Where(x => x.FontWeight == FontWeight.Bold));
 				tmp.AddRange(enumerable.Where(x => x.FontWeight == FontWeight.Normal));

--- a/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
@@ -84,7 +84,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			LoadCommits = new EnumCommand<TestMergeCommand>(TestMergeCommand.LoadCommits, this);
 		}
 
-		public TestMergeViewModel(Issue pullRequest, IReadOnlyList<PullRequestCommit> commits, Action<int> onActivate, Func<CancellationToken, Task> onLoadCommits, int? activeCommit = null) : this(onActivate)
+		public TestMergeViewModel(Issue pullRequest, IReadOnlyList<PullRequestCommit> commits, Action<int> onActivate, Func<CancellationToken, Task> onLoadCommits, int? activeCommit = null, bool selected = false) : this(onActivate)
 		{
 			if (pullRequest == null)
 				throw new ArgumentNullException(nameof(pullRequest));
@@ -103,6 +103,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				SelectedIndex = activeCommit.Value;
 			FontWeight = pullRequest.Labels.Any(x => x.Name.ToUpperInvariant().Contains("TEST MERGE")) ? FontWeight.Bold : FontWeight.Normal;
 			CanEdit = true;
+			this.selected = selected; // The use of the private property is intended; for avoiding calling activation function again
 		}
 
 		public TestMergeViewModel(TestMerge testMerge, Action<int> onActivate) : this(onActivate)

--- a/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
+++ b/src/Tgstation.Server.ControlPanel/ViewModels/TestMergeViewModel.cs
@@ -84,7 +84,7 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 			LoadCommits = new EnumCommand<TestMergeCommand>(TestMergeCommand.LoadCommits, this);
 		}
 
-		public TestMergeViewModel(Issue pullRequest, IReadOnlyList<PullRequestCommit> commits, Action<int> onActivate, Func<CancellationToken, Task> onLoadCommits, int? activeCommit = null, bool selected = false) : this(onActivate)
+		public TestMergeViewModel(Issue pullRequest, IReadOnlyList<PullRequestCommit> commits, Action<int> onActivate, Func<CancellationToken, Task> onLoadCommits, int? activeCommit = null) : this(onActivate)
 		{
 			if (pullRequest == null)
 				throw new ArgumentNullException(nameof(pullRequest));
@@ -103,7 +103,6 @@ namespace Tgstation.Server.ControlPanel.ViewModels
 				SelectedIndex = activeCommit.Value;
 			FontWeight = pullRequest.Labels.Any(x => x.Name.ToUpperInvariant().Contains("TEST MERGE")) ? FontWeight.Bold : FontWeight.Normal;
 			CanEdit = true;
-			this.selected = selected; // The use of the private property is intended; for avoiding calling activation function again
 		}
 
 		public TestMergeViewModel(TestMerge testMerge, Action<int> onActivate) : this(onActivate)

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Repository.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Repository.xaml
@@ -17,7 +17,7 @@
       <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Row="1">
-      <Grid IsEnabled="{Binding !Refreshing}">
+      <Grid IsEnabled="{Binding !Refreshing}" Margin="10,5,10,5">
         <Grid.RowDefinitions>
           <RowDefinition Height="Auto"/>
           <RowDefinition Height="Auto"/>
@@ -77,58 +77,56 @@
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
           <Grid>
-            <Grid.RowDefinitions>
-              <RowDefinition Height="Auto"/>
-              <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="400"/>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="6" />
+              <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <TextBlock Text="Checkout Sha:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding NewSha, Mode=TwoWay}" IsEnabled="{Binding CanSetSha}"/>
-            <TextBlock Text="Checkout Reference:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
-            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding NewReference, Mode=TwoWay}" IsEnabled="{Binding CanSetRef}"/>
+            <Grid Grid.Column="0">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+              </Grid.ColumnDefinitions>
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+              </Grid.RowDefinitions>
+              <TextBlock Text="Checkout Sha:" VerticalAlignment="Center" Margin="0,0,0,0" Grid.Column="0" Grid.Row="0"/>
+              <TextBox Grid.Column="1" Grid.Row="0" Margin="5,0,0,5" Text="{Binding NewSha, Mode=TwoWay}" IsEnabled="{Binding CanSetSha}"/>
+              <TextBlock Text="Checkout Reference:" VerticalAlignment="Center" Margin="0,0,0,0" Grid.Column="0" Grid.Row="1" />
+              <TextBox Grid.Column="1" Grid.Row="1" Margin="5,0,0,5" Text="{Binding NewReference, Mode=TwoWay}" IsEnabled="{Binding CanSetRef}"/>
+            </Grid>
+            <Grid Grid.Column="3">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+              </Grid.ColumnDefinitions>
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+              </Grid.RowDefinitions>
+              <TextBlock Text="Committer Name:" VerticalAlignment="Center" Margin="0,0,0,0" Grid.Column="0" Grid.Row="0"/>
+              <TextBox Grid.Column="1" Grid.Row="0" Margin="5,0,0,5" Text="{Binding NewCommitterName, Mode=TwoWay}" IsEnabled="{Binding CanChangeCommitter}"/>
+              <TextBlock Text="Committer E-Mail:" VerticalAlignment="Center" Margin="0,0,0,0" Grid.Column="0" Grid.Row="1" />
+              <TextBox Grid.Column="1" Grid.Row="1" Margin="5,0,0,5" Text="{Binding NewCommitterEmail, Mode=TwoWay}" IsEnabled="{Binding CanChangeCommitter}"/>
+            </Grid>
           </Grid>
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
           <Grid>
-            <Grid.RowDefinitions>
-              <RowDefinition Height="Auto"/>
-              <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="Auto"/>
-              <ColumnDefinition Width="400"/>
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <TextBlock Text="Committer Name:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-            <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding NewCommitterName, Mode=TwoWay}" IsEnabled="{Binding CanChangeCommitter}"/>
-            <TextBlock Text="Committer E-Mail:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
-            <TextBox Grid.Column="1" Grid.Row="1" Margin="50,0,0,5" Text="{Binding NewCommitterEmail, Mode=TwoWay}" IsEnabled="{Binding CanChangeCommitter}"/>
-          </Grid>
-          <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
-          <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-          <Grid>
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="1*"/>
-              <ColumnDefinition Width="1*"/>
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-              <RowDefinition Height="Auto"/>
-              <RowDefinition Height="Auto"/>
-              <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding NewAutoUpdatesKeepTestMerges, Mode=TwoWay}" IsEnabled="{Binding CanAutoUpdate}" ToolTip.Tip="Enabling this may cause automatic updates to fail due to merge conflicts" />
-              <TextBlock DockPanel.Dock="Right" Text="Automatic Updates Maintain Test Merges" ToolTip.Tip="Enabling this may cause automatic updates to fail due to merge conflicts" Margin="5,4,0,0" />
-            </DockPanel>
-            <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding NewAutoUpdatesSynchronize, Mode=TwoWay}" IsEnabled="{Binding CanAutoUpdate}"/>
-              <TextBlock DockPanel.Dock="Right" Text="Push Test Merge Commits to Temporary Branch" Margin="5,4,0,0" />
-            </DockPanel>
-            <CheckBox Background="White" Content="Show Merger Usernames in Public Metadata" IsChecked="{Binding NewShowTestMergeCommitters, Mode=TwoWay}" IsEnabled="{Binding CanShowTMCommitters}" Grid.Column="0" Grid.Row="1"/>
-            <CheckBox Background="White" Content="Post GitHub comment when test merge is deployed" IsChecked="{Binding NewPostTestMergeComment, Mode=TwoWay}" IsEnabled="{Binding CanShowTMCommitters}" Grid.Column="1" Grid.Row="1"/>
-            <CheckBox Background="White" Content="Create GitHub Deployment Statuses" IsChecked="{Binding NewGitHubDeployments, Mode=TwoWay}" IsEnabled="{Binding CanShowTMCommitters}" Grid.Column="0" Grid.Row="2"/>
+            <StackPanel Orientation="Vertical" Grid.Column="0" Spacing="6">
+              <CheckBox Background="White" Content="Automatic Updates Maintain Test Merges" IsChecked="{Binding NewAutoUpdatesKeepTestMerges, Mode=TwoWay}" IsEnabled="{Binding CanAutoUpdate}" ToolTip.Tip="Enabling this may cause automatic updates to fail due to merge conflicts" />
+              <CheckBox Background="White" Content="Push Test Merge Commits to Temporary Branch" IsChecked="{Binding NewAutoUpdatesSynchronize, Mode=TwoWay}" IsEnabled="{Binding CanAutoUpdate}"/>
+              <CheckBox Background="White" Content="Show Merger Usernames in Public Metadata" IsChecked="{Binding NewShowTestMergeCommitters, Mode=TwoWay}" IsEnabled="{Binding CanShowTMCommitters}" Grid.Column="0" Grid.Row="1"/>
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Grid.Column="1" Spacing="6">
+              <CheckBox Background="White" Content="Post GitHub comment when test merge is deployed" IsChecked="{Binding NewPostTestMergeComment, Mode=TwoWay}" IsEnabled="{Binding CanShowTMCommitters}" Grid.Column="1" Grid.Row="1"/>
+              <CheckBox Background="White" Content="Create GitHub Deployment Statuses" IsChecked="{Binding NewGitHubDeployments, Mode=TwoWay}" IsEnabled="{Binding CanShowTMCommitters}" Grid.Column="0" Grid.Row="2"/>
+            </StackPanel>
           </Grid>
         </StackPanel>
         <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" Grid.Row="2"/>
@@ -140,12 +138,12 @@
           </Grid.RowDefinitions>
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="400"/>
+            <ColumnDefinition Width="*"/>
           </Grid.ColumnDefinitions>
-          <TextBlock Text="Repository Access Username:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="0"/>
-          <TextBox Grid.Column="1" Grid.Row="0" Margin="50,0,0,5" Text="{Binding NewAccessUser, Mode=TwoWay}" IsEnabled="{Binding CanAccess}"/>
-          <TextBlock Text="Personal Access Token (repo scope) or Password for Non-GitHub Repos:" Margin="0,5,0,0" Grid.Column="0" Grid.Row="1" />
-          <TextBox Grid.Column="1" PasswordChar="*" Grid.Row="1" Margin="50,0,0,5" Text="{Binding NewAccessToken, Mode=TwoWay}" IsEnabled="{Binding CanAccess}"/>
+          <TextBlock Text="Repository Access Username:" Margin="0,0,0,7" VerticalAlignment="Center" Grid.Column="0" Grid.Row="0"/>
+          <TextBox Grid.Column="1" Grid.Row="0" Margin="5,0,0,7" Text="{Binding NewAccessUser, Mode=TwoWay}" IsEnabled="{Binding CanAccess}"/>
+          <TextBlock Text="PAT (GitHub) / Password (Others):" ToolTip.Tip="Personal Access Token (PAT) must be repo-scope, or use a password for non-GitHub repos" VerticalAlignment="Center"  Grid.Column="0" Grid.Row="1" />
+          <TextBox Grid.Column="1" PasswordChar="*" Grid.Row="1" Margin="5,0,0,0" Text="{Binding NewAccessToken, Mode=TwoWay}" IsEnabled="{Binding CanAccess}"/>
         </Grid>
         <StackPanel Orientation="Vertical" IsVisible="{Binding CloneAvailable}" Grid.Row="5">
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
@@ -193,25 +191,16 @@
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" Grid.Row="1"/>
           <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="1*"/>
-              <ColumnDefinition Width="1*"/>
+              <ColumnDefinition Width="*"/>
+              <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-              <RowDefinition Height="Auto"/>
-              <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <DockPanel Grid.Column="0" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding UpdateMerge, Mode=TwoWay}" IsEnabled="{Binding CanUpdateMerge}"/>
-              <TextBlock DockPanel.Dock="Right" Text="Merge From Tracked Origin Reference" Margin="5,4,0,0" />
-            </DockPanel>
-            <DockPanel Grid.Column="1" Grid.Row="0" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding UpdateHard, Mode=TwoWay}" IsEnabled="{Binding CanUpdate}"/>
-              <TextBlock DockPanel.Dock="Right" Text="{Binding UpdateText}" Margin="5,4,0,0" />
-            </DockPanel>
-            <DockPanel Grid.Column="0" Grid.Row="1" Margin="2">
-              <CheckBox Background="White" IsChecked="{Binding DeployAfter, Mode=TwoWay}" IsEnabled="{Binding CanDeploy}"/>
-              <TextBlock DockPanel.Dock="Right" Text="Deploy Code After Changes" Margin="5,4,0,0" />
-            </DockPanel>
+            <StackPanel Orientation="Vertical" Spacing="7" Grid.Column="0">
+              <CheckBox Background="White" Content="Merge From Tracked Origin Reference" IsChecked="{Binding UpdateMerge, Mode=TwoWay}" IsEnabled="{Binding CanUpdateMerge}"/>
+              <CheckBox Background="White" Content="{Binding UpdateText}" IsChecked="{Binding UpdateHard, Mode=TwoWay}" IsEnabled="{Binding CanUpdate}"/>
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Spacing="7" Grid.Column="2">
+              <CheckBox Background="White" Content="Deploy Code After Changes" IsChecked="{Binding DeployAfter, Mode=TwoWay}" IsEnabled="{Binding CanDeploy}"/>
+            </StackPanel>
           </Grid>
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" Grid.Row="3"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" Grid.Row="4"/>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/Repository.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/Repository.xaml
@@ -3,6 +3,11 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Tgstation.Server.ControlPanel.Views.Pages"
         x:Class="Tgstation.Server.ControlPanel.Views.Pages.Repository">
+  <UserControl.Styles>
+    <Style Selector="TextBox[IsReadOnly=True] /template/ Border#border">
+      <Setter Property="Opacity" Value="{DynamicResource ThemeDisabledOpacity}" />
+    </Style>
+  </UserControl.Styles>
   <Grid Background="#CFD6E5">
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>
@@ -17,17 +22,8 @@
       <Button DockPanel.Dock="Right" Content="X" Padding="0,0" Width="20" Height="20" Background="#4D6082" Foreground="White" Grid.Column="1" Command="{Binding Close}" Margin="0,0,5,0" />
     </Grid>
     <ScrollViewer Background="#CFD6E5" Margin="3" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" Grid.Row="1">
-      <Grid IsEnabled="{Binding !Refreshing}" Margin="10,5,10,5">
-        <Grid.RowDefinitions>
-          <RowDefinition Height="Auto"/>
-          <RowDefinition Height="Auto"/>
-          <RowDefinition Height="Auto"/>
-          <RowDefinition Height="Auto"/>
-          <RowDefinition Height="Auto"/>
-          <RowDefinition Height="Auto"/>
-          <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <Grid Grid.Row="0">
+      <StackPanel Orientation="Vertical" IsEnabled="{Binding !Refreshing}" Margin="10,5,10,5">
+        <Grid>
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="Auto"/>
@@ -40,39 +36,64 @@
           <TextBlock Grid.Column="2" Text="{Binding ErrorMessage}" IsVisible="{Binding Error}" Margin="0,10,0,0"/>
           <Button Grid.Column="3" Content="Refresh" Command="{Binding RefreshCommand}" Background="#CFD6E5" BorderBrush="#ADADAD"/>
         </Grid>
-        <StackPanel Orientation="Vertical" IsVisible="{Binding !CloneAvailable}" Grid.Row="1">
-          <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
-          <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
-          <StackPanel Orientation="Horizontal">
-            <TextBlock Text="Origin URL:"/>
-            <TextBlock Text="{Binding Repository.Origin}" Margin="5,0,0,0"/>
-          </StackPanel>
-          <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-            <TextBlock Text="Sha:"/>
-            <TextBlock Text="{Binding Repository.RevisionInformation.CommitSha}" Margin="5,0,0,0"/>
-          </StackPanel>
-          <StackPanel Orientation="Horizontal">
-            <TextBlock Text="Closest Origin Sha:"/>
-            <TextBlock Text="{Binding Repository.RevisionInformation.OriginCommitSha}" Margin="5,0,0,0"/>
-          </StackPanel>
-          <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-            <TextBlock Text="Reference:"/>
-            <TextBlock Text="{Binding Repository.Reference}" Margin="5,0,0,0"/>
-          </StackPanel>
-          <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-            <TextBlock Text="Committer Name:"/>
-            <TextBlock Text="{Binding Repository.CommitterName}" Margin="5,0,0,0"/>
-          </StackPanel>
-          <StackPanel Orientation="Horizontal">
-            <TextBlock Text="Committer E-Mail:"/>
-            <TextBlock Text="{Binding Repository.CommitterEmail}" Margin="5,0,0,0"/>
-          </StackPanel>
+        <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
+        <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
+        <Grid IsVisible="{Binding !CloneAvailable}">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="6" />
+            <ColumnDefinition Width="*" />
+          </Grid.ColumnDefinitions>
+          <Grid Grid.Column="0">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto"/>
+              <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBlock Text="Origin URL:" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"/>
+            <TextBox IsReadOnly="True" Text="{Binding Repository.Origin}" Margin="5,0,0,6" Grid.Column="1" Grid.Row="0"/>
+            <TextBlock Text="Sha:" Grid.Column="0" Grid.Row="1" VerticalAlignment="Center"/>
+            <TextBox IsReadOnly="True" Text="{Binding Repository.RevisionInformation.CommitSha}" Margin="5,0,0,6" Grid.Column="1" Grid.Row="1"/>
+            <TextBlock Text="Closest Origin Sha:" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center"/>
+            <TextBox IsReadOnly="True" Text="{Binding Repository.RevisionInformation.OriginCommitSha}" Margin="5,0,0,6" Grid.Column="1" Grid.Row="2"/>
+          </Grid>
+          <Grid Grid.Column="2">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto"/>
+              <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
+              <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBlock Text="Reference:" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"/>
+            <TextBox IsReadOnly="True" Text="{Binding Repository.Reference}" Margin="5,0,0,6" Grid.Column="1" Grid.Row="0"/>
+            <TextBlock Text="Committer Name:" Grid.Column="0" Grid.Row="1" VerticalAlignment="Center"/>
+            <TextBox IsReadOnly="True" Text="{Binding Repository.CommitterName}" Margin="5,0,0,6" Grid.Column="1" Grid.Row="1"/>
+            <TextBlock Text="Committer E-Mail:" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center"/>
+            <TextBox IsReadOnly="True" Text="{Binding Repository.CommitterEmail}" Margin="5,0,0,6" Grid.Column="1" Grid.Row="2"/>
+          </Grid>
+        </Grid>
+        <StackPanel Orientation="Vertical" IsVisible="{Binding !CloneAvailable}">
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition Width="*" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Width="99" VerticalAlignment="Center" Text="Credentials:" Grid.Column="0"/>
+            <TextBox IsReadOnly="True" Text="{Binding Repository.AccessUser}" Margin="5,0,0,0" Grid.Column="1"/>
+            <Button Command="{Binding RemoveCredentials}" Margin="5,0,0,0" Content="Clear Credentials" IsVisible="{Binding HasCredentials}" Grid.Column="2"/>
+          </Grid>
           <DockPanel LastChildFill="False" Margin="0,5,0,0">
             <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
-              <TextBlock Text="Credentials:"/>
-              <TextBlock Text="{Binding Repository.AccessUser}" Margin="5,0,0,0"/>
             </StackPanel>
-            <Button Command="{Binding RemoveCredentials}" Content="Clear Credentials" IsVisible="{Binding HasCredentials}" DockPanel.Dock="Right"/>
+            
           </DockPanel>
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
@@ -129,9 +150,9 @@
             </StackPanel>
           </Grid>
         </StackPanel>
-        <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0" Grid.Row="2"/>
-        <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5" Grid.Row="3"/>
-        <Grid Grid.Row="4">
+        <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
+        <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
+        <Grid>
           <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -145,7 +166,7 @@
           <TextBlock Text="PAT (GitHub) / Password (Others):" ToolTip.Tip="Personal Access Token (PAT) must be repo-scope, or use a password for non-GitHub repos" VerticalAlignment="Center"  Grid.Column="0" Grid.Row="1" />
           <TextBox Grid.Column="1" PasswordChar="*" Grid.Row="1" Margin="5,0,0,0" Text="{Binding NewAccessToken, Mode=TwoWay}" IsEnabled="{Binding CanAccess}"/>
         </Grid>
-        <StackPanel Orientation="Vertical" IsVisible="{Binding CloneAvailable}" Grid.Row="5">
+        <StackPanel Orientation="Vertical" IsVisible="{Binding CloneAvailable}">
           <Rectangle HorizontalAlignment="Stretch" Fill="#A0A0A0" Height="1" Margin="0,5,0,0"/>
           <Rectangle HorizontalAlignment="Stretch" Fill="#FFFFFF" Height="1" Margin="0,0,0,5"/>
           <Grid IsEnabled="{Binding CanClone}">
@@ -175,7 +196,7 @@
             <Button Command="{Binding Clone}" Content="Clone" Grid.Column="1"/>
           </Grid>
         </StackPanel>
-        <Grid IsVisible="{Binding !CloneAvailable}" Grid.Row="6">
+        <Grid IsVisible="{Binding !CloneAvailable}">
           <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -219,7 +240,7 @@
             <Button Content="{Binding DeleteText}" Grid.Column="3" Command="{Binding Delete}" Margin="0,0,5,0" />
           </Grid>
         </Grid>
-      </Grid>
+      </StackPanel>
     </ScrollViewer>
   </Grid>
 </UserControl>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml
@@ -1,7 +1,6 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Tgstation.Server.ControlPanel.Views.Pages.TestMergeManager">
-  
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>
@@ -25,7 +24,7 @@
       </Grid.RowDefinitions>
       <Grid Grid.Row="0" Grid.Column="1">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="80" />
           <ColumnDefinition Width="*" />
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="Auto" />
@@ -43,7 +42,7 @@
       </Grid>
       <Grid Grid.Row="1" Grid.Column="1" Margin="0,5,0,5">
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto"/>
+          <ColumnDefinition Width="80"/>
           <ColumnDefinition Width="*"/>
           <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
@@ -55,8 +54,8 @@
         <ItemsControl Items="{Binding SelectedTestMerges}">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
-              <Panel Background="#000000">
-                <Grid Margin="0,0,0,1" Background="#FFFFFF">
+              <Border Margin="5,5,5,0" BorderThickness="0,0,0,1" BorderBrush="Gray">
+                <Grid Margin="0,0,0,5" Background="#FFFFFF">
                   <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
@@ -64,7 +63,7 @@
                   <Grid Grid.Row="0">
                     <Grid.ColumnDefinitions>
                       <ColumnDefinition Width="Auto"/>
-                      <ColumnDefinition Width="*" MaxWidth="900"/>
+                      <ColumnDefinition Width="*"/>
                       <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <CheckBox Background="White" IsChecked="{Binding Selected, Mode=TwoWay}" IsEnabled="{Binding CanEdit}" Grid.Column="0"/>
@@ -87,7 +86,7 @@
                     <TextBox Text="{Binding Comment, Mode=TwoWay}" IsEnabled="{Binding CanEdit}" Grid.Row="1" Grid.Column="1" Margin="5,5,0,0"/>
                   </Grid>
                 </Grid>
-              </Panel>
+              </Border>
             </DataTemplate>
           </ItemsControl.ItemTemplate>
         </ItemsControl>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml
@@ -1,6 +1,7 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Tgstation.Server.ControlPanel.Views.Pages.TestMergeManager">
+  
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>
@@ -18,11 +19,40 @@
         <ColumnDefinition Width="5*"/>
       </Grid.ColumnDefinitions>
       <Grid.RowDefinitions>
-        <RowDefinition Height="500"/>
         <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="300"/>
       </Grid.RowDefinitions>
-      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="#FFFFFF" Grid.Row="0" Grid.Column="1">
-        <ItemsControl Items="{Binding TestMerges}">
+      <Grid Grid.Row="0" Grid.Column="1">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <TextBlock Text="Select open PR:" VerticalAlignment="Center" Grid.Column="0" />
+        <ComboBox Background="White" Items="{Binding AvailableTestMerges}" SelectedItem="{Binding CurrentTestMerge, Mode=TwoWay}" Grid.Column="1" Margin="5,0,5,0">
+          <ComboBox.ItemTemplate>
+            <DataTemplate>
+              <TextBlock Text="{Binding Title}" FontWeight="{Binding FontWeight}" />
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+        </ComboBox>
+        <Button Content="Open in Browser" Command="{Binding CurrentTestMerge.Link}" IsEnabled="{Binding CurrentTestMerge, Converter={x:Static ObjectConverters.IsNotNull}}" Margin="0,0,5,0" Grid.Column="2" />
+        <Button Content="Add" IsEnabled="{Binding CurrentTestMerge, Converter={x:Static ObjectConverters.IsNotNull}}" Command="{Binding AddPR}" Grid.Column="3" />
+      </Grid>
+      <Grid Grid.Row="1" Grid.Column="1" Margin="0,5,0,5">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto"/>
+          <ColumnDefinition Width="*"/>
+          <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <TextBlock Text="Manually Add:" VerticalAlignment="Center" Grid.Column="0"/>
+        <TextBox Text="{Binding ManualPR}" Watermark="GitHub link or PR number..." Margin="5,0,5,0" Grid.Column="1"/>
+        <Button Content="Add" Command="{Binding DirectAddPR}" Grid.Column="2"/>
+      </Grid>
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="#FFFFFF" Grid.Row="2" Grid.Column="1">
+        <ItemsControl Items="{Binding SelectedTestMerges}">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
               <Panel Background="#000000">
@@ -62,16 +92,6 @@
           </ItemsControl.ItemTemplate>
         </ItemsControl>
       </ScrollViewer>
-      <Grid Grid.Row="1" Grid.Column="1">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto"/>
-          <ColumnDefinition Width="*"/>
-          <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <TextBlock Text="Manual Add PR#:" Margin="0,5,5,0" Grid.Column="0"/>
-        <NumericUpDown Minimum="1" Value="{Binding ManualPR}" Margin="0,0,5,0" Grid.Column="1"/>
-        <Button Content="Add" Command="{Binding DirectAddPR}" Grid.Column="2"/>
-      </Grid>
     </Grid>
   </Grid>
 </UserControl>

--- a/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml
+++ b/src/Tgstation.Server.ControlPanel/Views/Pages/TestMergeManager.xaml
@@ -30,14 +30,14 @@
           <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
         <TextBlock Text="Select open PR:" VerticalAlignment="Center" Grid.Column="0" />
-        <ComboBox Background="White" Items="{Binding AvailableTestMerges}" SelectedItem="{Binding CurrentTestMerge, Mode=TwoWay}" Grid.Column="1" Margin="5,0,5,0">
+        <ComboBox Background="White" VirtualizationMode="Simple" Items="{Binding AvailableTestMerges}" SelectedItem="{Binding CurrentTestMerge, Mode=TwoWay}" Grid.Column="1" Margin="5,0,5,0">
           <ComboBox.ItemTemplate>
             <DataTemplate>
               <TextBlock Text="{Binding Title}" FontWeight="{Binding FontWeight}" />
             </DataTemplate>
           </ComboBox.ItemTemplate>
         </ComboBox>
-        <Button Content="Open in Browser" Command="{Binding CurrentTestMerge.Link}" IsEnabled="{Binding CurrentTestMerge, Converter={x:Static ObjectConverters.IsNotNull}}" Margin="0,0,5,0" Grid.Column="2" />
+        <Button Content="Open in Browser" Command="{Binding CurrentTestMerge.Link}" Margin="0,0,5,0" Grid.Column="2" />
         <Button Content="Add" IsEnabled="{Binding CurrentTestMerge, Converter={x:Static ObjectConverters.IsNotNull}}" Command="{Binding AddPR}" Grid.Column="3" />
       </Grid>
       <Grid Grid.Row="1" Grid.Column="1" Margin="0,5,0,5">
@@ -80,7 +80,7 @@
                       <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <TextBlock Text="Commit:" Grid.Row="0" Grid.Column="0" Margin="0,10,0,0"/>
-                    <ComboBox Items="{Binding Commits}" IsEnabled="{Binding CanEdit}" SelectedIndex="{Binding SelectedIndex, Mode=TwoWay}" Grid.Row="0" Grid.Column="1" Margin="5,5,0,0" IsVisible="{Binding CommitsLoaded}"/>
+                    <ComboBox Items="{Binding Commits}" VirtualizationMode="Simple" IsEnabled="{Binding CanEdit}" SelectedIndex="{Binding SelectedIndex, Mode=TwoWay}" Grid.Row="0" Grid.Column="1" Margin="5,5,0,0" IsVisible="{Binding CommitsLoaded}"/>
                     <Button Content="Load Commits" Command="{Binding LoadCommits}" Grid.Row="0" Grid.Column="1" Margin="5,5,0,0" IsVisible="{Binding !CommitsLoaded}"/>
                     <TextBlock Text="Comment:" Grid.Row="1" Grid.Column="0" Margin="0,10,0,0"/>
                     <TextBox Text="{Binding Comment, Mode=TwoWay}" IsEnabled="{Binding CanEdit}" Grid.Row="1" Grid.Column="1" Margin="5,5,0,0"/>


### PR DESCRIPTION
Preview below, changelog:
- Manual adding PRs for testmerge can now be done with a link, a simple number, etc in a freeform text box.
- Added some consistency to padding and general UI layout.
- Improvements to performance through putting all non-test-merged PRs into a simple selection, no need to render complex data for them

Note: navigating away from this view is still a little weird in terms of performance, but overall feels a lot better than before.

![Tgstation Server ControlPanel_2021-02-03_22-09-48](https://user-images.githubusercontent.com/10467687/106835279-6c565e00-666d-11eb-9ea6-27e3bbd9c943.png)
![Tgstation Server ControlPanel_2021-02-03_22-09-04](https://user-images.githubusercontent.com/10467687/106835623-074f3800-666e-11eb-9c17-51fdfb8190d7.png)
